### PR TITLE
⚡ Bolt: Short-circuit early returns in JS/CSS minification

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,4 @@
 
 **Learning:** Calculating file sizes or counts via recursive directory scanning (`dirlist`) on every WP-admin load creates a severe bottleneck that can crash or slow down the settings page.
 **Action:** Always use WordPress Transients to cache expensive file system results, and invalidate these transients within `clear_cache` methods.
+## 2025-01-20 - Early Return Before Expensive Computations\n\n**Learning:** High-frequency operations like `Util::get_local_path` (which parses URLs) were being computed before short-circuit logic (`is_user_logged_in`, `empty( $href )`) in `minify_css` and `minify_js`. This caused significant performance overhead as they run on every page load.\n**Action:** Always place lightweight conditionals before heavy variable assignments. Avoid executing computationally expensive operations unless strictly necessary.

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -953,9 +953,15 @@ class Main {
 	 * @return string Modified link tag with minified CSS.
 	 */
 	public function minify_css( $tag, $handle, $href ) {
+		// ⚡ Bolt: Early return for logged-in users, empty URLs, or excluded handles
+		// to avoid the expensive Util::get_local_path() computation.
+		if ( is_user_logged_in() || empty( $href ) || in_array( $handle, $this->exclude_css, true ) ) {
+			return $tag;
+		}
+
 		$local_path = Util::get_local_path( $href );
 
-		if ( is_user_logged_in() || empty( $href ) || in_array( $handle, $this->exclude_css, true ) || $this->is_css_minified( $local_path ) ) {
+		if ( $this->is_css_minified( $local_path ) ) {
 			return $tag;
 		}
 
@@ -983,9 +989,15 @@ class Main {
 	 * @return string Modified script tag with minified JavaScript.
 	 */
 	public function minify_js( $tag, $handle, $src ) {
+		// ⚡ Bolt: Early return for logged-in users, empty URLs, or excluded handles
+		// to avoid the expensive Util::get_local_path() computation.
+		if ( is_user_logged_in() || empty( $src ) || in_array( $handle, $this->exclude_js, true ) ) {
+			return $tag;
+		}
+
 		$local_path = Util::get_local_path( $src );
 
-		if ( is_user_logged_in() || empty( $src ) || in_array( $handle, $this->exclude_js, true ) || $this->is_js_minified( $local_path ) ) {
+		if ( $this->is_js_minified( $local_path ) ) {
 			return $tag;
 		}
 


### PR DESCRIPTION
💡 **What:** 
Moved the `is_user_logged_in()`, `empty()`, and `in_array()` exclusion checks in `minify_css` and `minify_js` above the `Util::get_local_path()` assignment.

🎯 **Why:** 
Previously, `Util::get_local_path()` (which runs `wp_parse_url`, path replacements, and directory normalizations) was being computed unconditionally on every script and style enqueued on the frontend, even if the user was logged in, the URL was empty, or the handle was explicitly excluded. Because `minify_css` and `minify_js` hook into `style_loader_tag` and `script_loader_tag` respectively, these computationally expensive operations ran dozens of times per page view completely unnecessarily. By leveraging PHP's short-circuiting logic with early returns, we only parse the paths for strings we actually intend to minify.

📊 **Impact:** 
Significant CPU cycle reduction on all frontend page loads. Eliminates dozens of redundant `wp_parse_url` and `str_replace` operations for non-minified assets and logged-in users, reducing total time-to-first-byte (TTFB).

🔬 **Measurement:** 
Compare TTFB or overall execution time via Query Monitor on a page heavy with enqueued assets (especially for a logged-in user or when minification exclusions are set) before and after this change.

---
*PR created automatically by Jules for task [7427149993431957554](https://jules.google.com/task/7427149993431957554) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance for CSS and JavaScript minification by optimizing conditional checks. The system now skips unnecessary processing for logged-in users and empty assets, reducing page load overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->