### PR TITLE
⚡ Bolt: Prevent autoloading of wppo_img_info option

### DIFF
--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -681,7 +681,7 @@ class Img_Converter {
 	 */
 	public static function set_img_info( array $img_info ): void {
 		self::$deferred_img_info = $img_info;
-		update_option( 'wppo_img_info', $img_info );
+		update_option( 'wppo_img_info', $img_info, false );
 	}
 
 	/**
@@ -696,7 +696,7 @@ class Img_Converter {
 				$img_info['completed']['avif'] = array();
 				// Write cleared completed to the DB immediately so that
 				// commit_img_info()'s live re-read cannot merge old entries back in.
-				update_option( 'wppo_img_info', $img_info );
+				update_option( 'wppo_img_info', $img_info, false );
 				return $img_info;
 			}
 		);
@@ -755,7 +755,7 @@ class Img_Converter {
 				}
 			}
 
-			update_option( 'wppo_img_info', self::$deferred_img_info );
+			update_option( 'wppo_img_info', self::$deferred_img_info, false );
 		}
 	}
 }

--- a/performance-optimisation.php
+++ b/performance-optimisation.php
@@ -33,8 +33,8 @@ if ( ! defined( 'WPPO_PLUGIN_URL' ) ) {
 	define( 'WPPO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 }
 
-if (!defined('WPPO_VERSION')) {
-	define('WPPO_VERSION', '1.5.0');
+if ( ! defined( 'WPPO_VERSION' ) ) {
+	define( 'WPPO_VERSION', '1.5.0' );
 }
 
 // Include the main class file.
@@ -49,12 +49,11 @@ new Main();
  * @since 1.0.0
  * Includes the activation class and runs the activation process.
  */
-function wppo_activate(): void
-{
+function wppo_activate(): void {
 	require_once WPPO_PLUGIN_PATH . 'includes/class-activate.php';
 	Activate::init();
 }
-register_activation_hook(__FILE__, 'wppo_activate');
+register_activation_hook( __FILE__, 'wppo_activate' );
 
 /**
  * Deactivation hook callback function.
@@ -62,9 +61,8 @@ register_activation_hook(__FILE__, 'wppo_activate');
  * @since 1.0.0
  * Includes the deactivation class and runs the deactivation process.
  */
-function wppo_deactivate(): void
-{
+function wppo_deactivate(): void {
 	require_once WPPO_PLUGIN_PATH . 'includes/class-deactivate.php';
 	Deactivate::init();
 }
-register_deactivation_hook(__FILE__, 'wppo_deactivate');
+register_deactivation_hook( __FILE__, 'wppo_deactivate' );

--- a/performance-optimisation.php
+++ b/performance-optimisation.php
@@ -20,17 +20,17 @@ use PerformanceOptimise\Inc\Activate;
 use PerformanceOptimise\Inc\Deactivate;
 use PerformanceOptimise\Inc\Main;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
 // Define plugin constants.
-if (!defined('WPPO_PLUGIN_PATH')) {
-	define('WPPO_PLUGIN_PATH', wp_normalize_path(plugin_dir_path(__FILE__)));
+if ( ! defined( 'WPPO_PLUGIN_PATH' ) ) {
+	define( 'WPPO_PLUGIN_PATH', wp_normalize_path( plugin_dir_path( __FILE__ ) ) );
 }
 
-if (!defined('WPPO_PLUGIN_URL')) {
-	define('WPPO_PLUGIN_URL', plugin_dir_url(__FILE__));
+if ( ! defined( 'WPPO_PLUGIN_URL' ) ) {
+	define( 'WPPO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 }
 
 if (!defined('WPPO_VERSION')) {


### PR DESCRIPTION
💡 What: The optimization implemented
This pull request modifies `includes/class-img-converter.php` to pass `false` as the third parameter (`$autoload`) when updating the `wppo_img_info` option.

🎯 Why: The performance problem it solves
The `wppo_img_info` option tracks potentially thousands of images' processing status. By default, `update_option()` sets options to autoload, which means this large array is fetched and kept in memory on every single WordPress page load (both frontend and admin), causing severe memory bloat.

📊 Impact: Expected performance improvement
Significantly reduces memory footprint and database overhead on every page load by preventing the large `wppo_img_info` array from being autoloaded unnecessarily. The data will now only be queried via `get_option()` when explicitly needed by the plugin's background processes or admin dashboard.

🔬 Measurement: How to verify the improvement
Inspect the `wp_options` table in the database and verify that the `autoload` column for the `wppo_img_info` option is set to `no` after the plugin processes an image or updates its status.

---
*PR created automatically by Jules for task [9048255202989360558](https://jules.google.com/task/9048255202989360558) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced site load by changing how image conversion status is stored so it no longer autoloads on every request, improving database performance.
  * Minor internal formatting updates for consistency; no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->