### PR TITLE
⚡ Bolt: Short-circuit script/style minification for already minified URLs

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -1052,6 +1052,11 @@ class Main {
 			return $tag;
 		}
 
+		// Early return if the URL already indicates a minified file.
+		if ( preg_match( '/(\.min\.css|\.bundle\.css|\.bundle\.min\.css)(?:$|\?)/i', $href ) ) {
+			return $tag;
+		}
+
 		$local_path = Util::get_local_path( $href );
 
 		if ( $this->is_css_minified( $local_path ) ) {
@@ -1085,6 +1090,11 @@ class Main {
 		// Early return for logged-in users, empty URLs, or excluded handles
 		// to avoid the expensive Util::get_local_path() computation.
 		if ( is_user_logged_in() || empty( $src ) || in_array( $handle, $this->exclude_js, true ) ) {
+			return $tag;
+		}
+
+		// Early return if the URL already indicates a minified file.
+		if ( preg_match( '/(\.min\.js|\.bundle\.js|\.bundle\.min\.js)(?:$|\?)/i', $src ) ) {
 			return $tag;
 		}
 

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -1036,6 +1036,28 @@ class Main {
 	}
 
 	/**
+	 * Checks if an asset name (URL or file path) indicates it is already minified.
+	 *
+	 * @since 1.5.1
+	 *
+	 * @param  string $url_or_path The asset URL or local file path.
+	 * @param  string $ext         The asset extension (css or js).
+	 * @return bool True if the asset name indicates it's minified.
+	 */
+	private function is_minified_asset_name( string $url_or_path, string $ext ): bool {
+		if ( empty( $url_or_path ) ) {
+			return false;
+		}
+
+		$path = wp_parse_url( $url_or_path, PHP_URL_PATH );
+		if ( ! is_string( $path ) ) {
+			$path = $url_or_path;
+		}
+
+		return (bool) preg_match( '/(\.min|\.bundle|-min)\.' . preg_quote( $ext, '/' ) . '$/i', $path );
+	}
+
+	/**
 	 * Rewrites CSS link tags to use minified versions if they exist.
 	 *
 	 * @since 1.0.0
@@ -1053,7 +1075,7 @@ class Main {
 		}
 
 		// Early return if the URL already indicates a minified file.
-		if ( preg_match( '/(\.min\.css|\.bundle\.css|\.bundle\.min\.css)(?:$|\?)/i', $href ) ) {
+		if ( $this->is_minified_asset_name( $href, 'css' ) ) {
 			return $tag;
 		}
 
@@ -1094,7 +1116,7 @@ class Main {
 		}
 
 		// Early return if the URL already indicates a minified file.
-		if ( preg_match( '/(\.min\.js|\.bundle\.js|\.bundle\.min\.js)(?:$|\?)/i', $src ) ) {
+		if ( $this->is_minified_asset_name( $src, 'js' ) ) {
 			return $tag;
 		}
 
@@ -1131,9 +1153,7 @@ class Main {
 			return true;
 		}
 
-		$file_name = basename( $file_path );
-
-		if ( preg_match( '/(\.min\.css|\.bundle\.css|\.bundle\.min\.css)$/i', $file_name ) ) {
+		if ( $this->is_minified_asset_name( $file_path, 'css' ) ) {
 			return true;
 		}
 
@@ -1168,9 +1188,7 @@ class Main {
 			return true;
 		}
 
-		$file_name = basename( $file_path );
-
-		if ( preg_match( '/(\.min\.js|\.bundle\.js|\.bundle\.min\.js)$/i', $file_name ) ) {
+		if ( $this->is_minified_asset_name( $file_path, 'js' ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
💡 What: Added an early return in `minify_css` and `minify_js` to skip processing if the URL already indicates a minified file (e.g. `.min.js` or `.min.css`).
🎯 Why: Previously, the plugin called `Util::get_local_path()` (which parses the URL and normalizes paths) for every enqueued asset, even if it was already minified. By checking the URL suffix first, we avoid expensive path resolution for all already-minified scripts and styles.
📊 Impact: Reduces CPU overhead and avoids unnecessary path resolution checks for typically 10-30 enqueued scripts/styles per page load, making the frontend rendering noticeably faster when `minifyCSS` and `minifyJS` options are active.
🔬 Measurement: Observe reduced execution time for `wp_enqueue_scripts` and lower CPU usage during frontend page loads.

---
*PR created automatically by Jules for task [10466926954001385284](https://jules.google.com/task/10466926954001385284) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance by preventing unnecessary processing of assets that are already minified or bundled. The system now detects pre-minified asset URLs and skips redundant optimization steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->