### PR TITLE
⚡ Bolt: [performance improvement] Optimize file minification checks using stream reads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,7 @@
 **Action:** Always use WordPress Transients to cache expensive file system results, and invalidate these transients within `clear_cache` methods.
 ## 2025-01-20 - Early Return Before Expensive Computations\n\n**Learning:** High-frequency operations like `Util::get_local_path` (which parses URLs) were being computed before short-circuit logic (`is_user_logged_in`, `empty( $href )`) in `minify_css` and `minify_js`. This caused significant performance overhead as they run on every page load.\n**Action:** Always place lightweight conditionals before heavy variable assignments. Avoid executing computationally expensive operations unless strictly necessary.
 
+
+## 2026-06-02 - Streaming File Reads vs file_get_contents
+**Learning:** Using `file_get_contents` to read entire files into memory just to count newlines (using `substr_count`) is highly inefficient for large compiled assets (JS/CSS) and causes memory spikes. This is a common bottleneck when checking if files are minified on the fly.
+**Action:** Use native PHP streaming functions (`fopen` and `fgets`) with early returns (`break`) to count lines efficiently without loading the entire file into memory. Always close the file handle (`fclose`) when done.

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -1220,18 +1220,24 @@ class Main {
 			return true;
 		}
 
-		$css_content = $this->filesystem->get_contents( $file_path );
-		if ( ! is_string( $css_content ) ) {
+		$handle = @fopen( $file_path, 'r' );
+		if ( ! $handle ) {
 			return true;
 		}
 
-		$line_count = ( '' === $css_content ) ? 0 : substr_count( $css_content, "\n" ) + 1;
+		$line_count = 0;
+		while ( ! feof( $handle ) ) {
+			fgets( $handle );
+			$line_count++;
 
-		if ( 10 >= $line_count ) {
-			return true;
+			if ( $line_count > 10 ) {
+				fclose( $handle );
+				return false;
+			}
 		}
 
-		return false;
+		fclose( $handle );
+		return true;
 	}
 
 	/**
@@ -1255,17 +1261,23 @@ class Main {
 			return true;
 		}
 
-		$js_content = $this->filesystem->get_contents( $file_path );
-		if ( ! is_string( $js_content ) ) {
+		$handle = @fopen( $file_path, 'r' );
+		if ( ! $handle ) {
 			return true;
 		}
 
-		$line_count = ( '' === $js_content ) ? 0 : substr_count( $js_content, "\n" ) + 1;
+		$line_count = 0;
+		while ( ! feof( $handle ) ) {
+			fgets( $handle );
+			$line_count++;
 
-		if ( 10 >= $line_count ) {
-			return true;
+			if ( $line_count > 10 ) {
+				fclose( $handle );
+				return false;
+			}
 		}
 
-		return false;
+		fclose( $handle );
+		return true;
 	}
 }

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -1220,24 +1220,7 @@ class Main {
 			return true;
 		}
 
-		$handle = @fopen( $file_path, 'r' );
-		if ( ! $handle ) {
-			return true;
-		}
-
-		$line_count = 0;
-		while ( ! feof( $handle ) ) {
-			fgets( $handle );
-			$line_count++;
-
-			if ( $line_count > 10 ) {
-				fclose( $handle );
-				return false;
-			}
-		}
-
-		fclose( $handle );
-		return true;
+		return $this->is_file_minified( $file_path );
 	}
 
 	/**
@@ -1261,23 +1244,53 @@ class Main {
 			return true;
 		}
 
-		$handle = @fopen( $file_path, 'r' );
-		if ( ! $handle ) {
-			return true;
-		}
+		return $this->is_file_minified( $file_path );
+	}
 
-		$line_count = 0;
-		while ( ! feof( $handle ) ) {
-			fgets( $handle );
-			$line_count++;
+	/**
+	 * Shared logic to determine if a file is minified by checking its line count.
+	 * Uses streaming reads if possible, falling back to full reads if needed.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  string $file_path Path to the file.
+	 * @return bool True if the file is minified (<= 10 lines), false otherwise.
+	 */
+	private function is_file_minified( $file_path ) {
+		// Optimize using native PHP streaming if the WP filesystem is using 'direct' access.
+		if ( isset( $this->filesystem->method ) && 'direct' === $this->filesystem->method ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+			$handle = @fopen( $file_path, 'r' );
+			if ( $handle ) {
+				$line_count = 0;
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fgets
+				while ( false !== fgets( $handle ) ) {
+					++$line_count;
 
-			if ( $line_count > 10 ) {
+					if ( $line_count > 10 ) {
+						// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+						fclose( $handle );
+						return false;
+					}
+				}
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 				fclose( $handle );
-				return false;
+				return true;
 			}
 		}
 
-		fclose( $handle );
-		return true;
+		// Fallback for non-direct filesystems (e.g., FTP/SSH).
+		$content = $this->filesystem->get_contents( $file_path );
+		if ( ! is_string( $content ) ) {
+			return true;
+		}
+
+		$line_count = ( '' === $content ) ? 0 : substr_count( $content, "\n" ) + 1;
+
+		if ( 10 >= $line_count ) {
+			return true;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
💡 **What:** Replaced the `file_get_contents()` and `substr_count()` logic in `is_css_minified` and `is_js_minified` with a line-by-line reading approach using `fopen()` and `fgets()`.
🎯 **Why:** The previous approach loaded entire large CSS/JS files into memory simply to count the number of newlines. This creates a severe memory and processing bottleneck when checking asset minification statuses on the fly.
📊 **Impact:** Drastically reduces memory consumption and CPU overhead when parsing unminified static assets. Changes an $O(N)$ full-file string parse into a maximum $O(1)$ fast check bounding to at most 11 lines read.
🔬 **Measurement:** Memory usage profile will remain flat instead of spiking according to file size when hitting `includes/class-main.php` during un-cached visits.

---
*PR created automatically by Jules for task [453806910967175319](https://jules.google.com/task/453806910967175319) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance of minified file detection by using streaming reads instead of loading entire file contents into memory, reducing resource consumption for large CSS and JavaScript files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->