### PR TITLE
⚡ Bolt: Optimize URL Parsing in Cron Batching

### DIFF
--- a/.github/workflows/qoder-auto-review.yml
+++ b/.github/workflows/qoder-auto-review.yml
@@ -34,7 +34,7 @@ jobs:
           QODER_CONFIG_DIR: /home/runner/.qoder
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          qoder_personal_access_token: ${{ secrets.QODER_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          qoder_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             /review-pr
             REPO:${{ github.repository }} PR_NUMBER:${{ github.event.pull_request.number }}

--- a/.github/workflows/qoder-auto-review.yml
+++ b/.github/workflows/qoder-auto-review.yml
@@ -34,7 +34,7 @@ jobs:
           QODER_CONFIG_DIR: /home/runner/.qoder
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          qoder_personal_access_token: ${{ secrets.GITHUB_TOKEN }}
+          qoder_personal_access_token: ${{ secrets.QODER_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           prompt: |
             /review-pr
             REPO:${{ github.repository }} PR_NUMBER:${{ github.event.pull_request.number }}

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,7 @@
 ## 2025-01-22 - WPCS Error Suppression
 **Learning:** WordPress Coding Standards (WPCS) strongly discourages using the error suppression operator (`@`) before functions like `fopen()`. While it suppresses warnings when a file doesn't exist, it is better to rely on `file_exists()` before opening or catch exceptions.
 **Action:** Never use `@fopen()`. Rely on `file_exists()` and standard `$handle = fopen(...)` with a falsy check, and use `// phpcs:ignore` annotations to bypass strict file system rules.
+## 2025-01-22 - Optimize URL Parsing in Cron Loops
+
+**Learning:** URL normalization (`rtrim`, `home_url`) inside a batch loop that processes hundreds of items (like `class-cron.php`) can redundantly compute the same fixed strings for every iteration.
+**Action:** When iterating over items in a batch process, always extract and pre-compute operations on fixed configuration arrays (like exclusion URLs) outside the main processing loop to minimize redundant string manipulations.

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -136,20 +136,23 @@ class Cron {
 			return;
 		}
 
-		$options      = get_option( 'wppo_settings', array() );
-		$exclude_urls = Util::process_urls( $options['preload_settings']['excludePreloadCache'] ?? array() );
+		$options          = get_option( 'wppo_settings', array() );
+		$raw_exclude_urls = Util::process_urls( $options['preload_settings']['excludePreloadCache'] ?? array() );
+
+		$normalized_exclude_urls = array();
+		foreach ( $raw_exclude_urls as $exclude_url ) {
+			$exclude_url = rtrim( $exclude_url, '/' );
+			if ( 0 !== strpos( $exclude_url, 'http' ) ) {
+				$exclude_url = home_url( $exclude_url );
+			}
+			$normalized_exclude_urls[] = $exclude_url;
+		}
 
 		foreach ( $query_batch_posts as $page_id ) {
 			$page_url       = get_permalink( $page_id );
 			$should_exclude = false;
 
-			foreach ( $exclude_urls as $exclude_url ) {
-				$exclude_url = rtrim( $exclude_url, '/' );
-
-				if ( 0 !== strpos( $exclude_url, 'http' ) ) {
-					$exclude_url = home_url( $exclude_url );
-				}
-
+			foreach ( $normalized_exclude_urls as $exclude_url ) {
 				if ( false !== strpos( $exclude_url, '(.*)' ) ) {
 					$exclude_prefix = str_replace( '(.*)', '', $exclude_url );
 


### PR DESCRIPTION
💡 What: Moved the normalisation of `$exclude_urls` (using `rtrim` and `home_url`) to a separate loop that runs *before* the main `$query_batch_posts` loop in `schedule_page_cron_jobs` (in `includes/class-cron.php`).

🎯 Why: To solve a redundant computation bottleneck. In the previous implementation, the script was executing the same URL string normalisation against the exclusion array for every single page (up to 200 times per batch). 

📊 Impact: Reduces repetitive string operations (O(N*M)) inside the main static cache generation cron batch loop, lowering CPU usage and speeding up the cron task execution.

🔬 Measurement: Code review confirms the outer loop runs exactly once per batch to pre-process the exclude array, leaving the inner loop to only perform string matching against the pre-normalised array. Tested with PHP syntax and WPCS checks.

---
*PR created automatically by Jules for task [177159811131248343](https://jules.google.com/task/177159811131248343) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page cron processing performance by reducing repeated URL normalization work during batch runs.
  * Exclusion rules are now handled more efficiently, which should speed up large jobs and lower unnecessary processing overhead.

* **Documentation**
  * Added a note describing the URL parsing optimization and guidance for avoiding repeated work inside loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->