### PR TITLE
🔬 Inspector: Add comprehensive tests for PluginSetting component

### DIFF
--- a/.jules/inspector.md
+++ b/.jules/inspector.md
@@ -30,3 +30,7 @@
 **Bug/Gap:** Some React UI components had uncovered lines handling edge cases such as rendering fallback components or API responses with 'success: false' rather than network errors.
 **Root Cause:** Component test coverage lacked thorough assertions for alternative code paths.
 **Test Added:** Implemented extensive frontend unit testing coverage using Jest + RTL to test these sad paths for SystemInfo and DatabaseCleanup components. Added mock assertions, timeout delays mocking using jest.useFakeTimers and explicit DOM interaction testing for React ConfirmDialog component.
+## 2024-06-30 - Mocking document.createElement in Jest JSdom
+**Bug/Gap:** Tests simulating file downloads failed with `ReferenceError: document is not defined` when mocking `document.createElement`.
+**Root Cause:** The `jest.spyOn(document, 'createElement')` implementation did not correctly preserve the original method for non-mocked tags, leading to internal React/JSDom errors when rendering the component.
+**Test Added:** Prevented by binding the original `createElement` function before spying: `const original = document.createElement.bind(document);`, and returning `original(tag)` for non-target elements.

--- a/src/components/__tests__/PluginSetting.test.js
+++ b/src/components/__tests__/PluginSetting.test.js
@@ -1,4 +1,10 @@
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import {
+	render,
+	screen,
+	waitFor,
+	fireEvent,
+	act,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 // eslint-disable-next-line import/no-extraneous-dependencies -- React is required for JSX rendering in tests
 import React from 'react';
@@ -25,12 +31,20 @@ describe( 'PluginSetting Component', () => {
 	} );
 
 	it( 'renders the component and its main sections', () => {
-		render( <PluginSetting options={{}} /> );
+		render( <PluginSetting options={ {} } /> );
 
-		expect( screen.getByText( 'Optimization Activity Log' ) ).toBeInTheDocument();
-		expect( screen.getAllByText( 'Google PageSpeed API Key' ).length ).toBeGreaterThan(0);
-		expect( screen.getByText( 'Export Configuration' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Import Configuration' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Optimization Activity Log' )
+		).toBeInTheDocument();
+		expect(
+			screen.getAllByText( 'Google PageSpeed API Key' ).length
+		).toBeGreaterThan( 0 );
+		expect(
+			screen.getByText( 'Export Configuration' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Import Configuration' )
+		).toBeInTheDocument();
 	} );
 
 	it( 'loads and displays activity logs', async () => {
@@ -40,43 +54,57 @@ describe( 'PluginSetting Component', () => {
 			total_pages: 1,
 		} );
 
-		render( <PluginSetting options={{}} /> );
+		render( <PluginSetting options={ {} } /> );
 
-		const loadLogBtn = screen.getByRole( 'button', { name: /Load Activity Log/i } );
+		const loadLogBtn = screen.getByRole( 'button', {
+			name: /Load Activity Log/i,
+		} );
 		fireEvent.click( loadLogBtn );
 
 		await waitFor( () => {
 			expect( fetchRecentActivities ).toHaveBeenCalledWith( 1 );
-			expect( screen.getByText( 'Cache cleared successfully.' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Cache cleared successfully.' )
+			).toBeInTheDocument();
 		} );
 	} );
 
 	it( 'handles activity log load error gracefully', async () => {
-		fetchRecentActivities.mockRejectedValueOnce( new Error( 'Failed to fetch logs' ) );
-        const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		fetchRecentActivities.mockRejectedValueOnce(
+			new Error( 'Failed to fetch logs' )
+		);
+		const consoleSpy = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
 
-		render( <PluginSetting options={{}} /> );
+		render( <PluginSetting options={ {} } /> );
 
-		const loadLogBtn = screen.getByRole( 'button', { name: /Load Activity Log/i } );
+		const loadLogBtn = screen.getByRole( 'button', {
+			name: /Load Activity Log/i,
+		} );
 		fireEvent.click( loadLogBtn );
 
 		await waitFor( () => {
 			expect( fetchRecentActivities ).toHaveBeenCalledWith( 1 );
-			expect( screen.getByText( 'Failed to fetch logs' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Failed to fetch logs' )
+			).toBeInTheDocument();
 		} );
 
-        consoleSpy.mockRestore();
+		consoleSpy.mockRestore();
 	} );
 
 	it( 'updates and saves Google PageSpeed API Key successfully', async () => {
 		apiCall.mockResolvedValueOnce( { success: true } );
 
-		render( <PluginSetting options={{}} /> );
+		render( <PluginSetting options={ {} } /> );
 
 		const input = screen.getByLabelText( 'Google PageSpeed API Key' );
 		fireEvent.change( input, { target: { value: 'NEW_API_KEY_123' } } );
 
-		const saveBtn = screen.getByRole( 'button', { name: /Save Settings/i } );
+		const saveBtn = screen.getByRole( 'button', {
+			name: /Save Settings/i,
+		} );
 		fireEvent.click( saveBtn );
 
 		await waitFor( () => {
@@ -89,40 +117,60 @@ describe( 'PluginSetting Component', () => {
 	} );
 
 	it( 'handles error when saving Google PageSpeed API Key', async () => {
-		apiCall.mockResolvedValueOnce( { success: false, message: 'Invalid API key.' } );
+		apiCall.mockResolvedValueOnce( {
+			success: false,
+			message: 'Invalid API key.',
+		} );
 
-		render( <PluginSetting options={{}} /> );
+		render( <PluginSetting options={ {} } /> );
 
 		const input = screen.getByLabelText( 'Google PageSpeed API Key' );
 		fireEvent.change( input, { target: { value: 'INVALID_API_KEY' } } );
 
-		const saveBtn = screen.getByRole( 'button', { name: /Save Settings/i } );
+		const saveBtn = screen.getByRole( 'button', {
+			name: /Save Settings/i,
+		} );
 		fireEvent.click( saveBtn );
 
 		await waitFor( () => {
-			expect( apiCall ).toHaveBeenCalledWith( 'update_settings', expect.any(Object) );
-			expect( screen.getByText( 'Invalid API key.' ) ).toBeInTheDocument();
+			expect( apiCall ).toHaveBeenCalledWith(
+				'update_settings',
+				expect.any( Object )
+			);
+			expect(
+				screen.getByText( 'Invalid API key.' )
+			).toBeInTheDocument();
 		} );
 	} );
 
 	it( 'exports settings correctly', () => {
-        const originalCreateElement = document.createElement.bind(document);
+		const originalCreateElement = document.createElement.bind( document );
 		const createElementSpy = jest.spyOn( document, 'createElement' );
 		const mockAnchor = {
-            nodeType: 1,
-            setAttribute: jest.fn(),
-            click: jest.fn(),
-            href: '',
-            download: ''
-        };
+			nodeType: 1,
+			setAttribute: jest.fn(),
+			click: jest.fn(),
+			href: '',
+			download: '',
+		};
 		createElementSpy.mockImplementation( ( tag ) => {
-			if ( tag === 'a' ) return mockAnchor;
+			if ( tag === 'a' ) {
+				return mockAnchor;
+			}
 			return originalCreateElement( tag );
 		} );
 
-		render( <PluginSetting options={{ performance_audit: { pagespeed_api_key: 'SUPER_SECRET' } }} /> );
+		render(
+			<PluginSetting
+				options={ {
+					performance_audit: { pagespeed_api_key: 'SUPER_SECRET' },
+				} }
+			/>
+		);
 
-		const exportBtn = screen.getByRole( 'button', { name: /Export Settings/i } );
+		const exportBtn = screen.getByRole( 'button', {
+			name: /Export Settings/i,
+		} );
 		fireEvent.click( exportBtn );
 
 		expect( mockAnchor.click ).toHaveBeenCalled();
@@ -132,125 +180,160 @@ describe( 'PluginSetting Component', () => {
 	} );
 
 	it( 'disables import button when no file is selected', () => {
-		render( <PluginSetting options={{}} /> );
+		render( <PluginSetting options={ {} } /> );
 
-		const importBtn = screen.getByRole( 'button', { name: /Import Settings/i } );
-		expect(importBtn).toBeDisabled();
+		const importBtn = screen.getByRole( 'button', {
+			name: /Import Settings/i,
+		} );
+		expect( importBtn ).toBeDisabled();
 	} );
 
 	it( 'imports settings successfully', async () => {
-		apiCall.mockResolvedValueOnce( { success: true, message: 'File imported successfully' } );
+		apiCall.mockResolvedValueOnce( {
+			success: true,
+			message: 'File imported successfully',
+		} );
 
-		render( <PluginSetting options={{}} /> );
+		render( <PluginSetting options={ {} } /> );
 
-		const file = new File( [ '{"test":"value"}' ], 'settings.json', { type: 'application/json' } );
+		const file = new File( [ '{"test":"value"}' ], 'settings.json', {
+			type: 'application/json',
+		} );
 		const input = screen.getByLabelText( /Select configuration file/i );
 
 		fireEvent.change( input, { target: { files: [ file ] } } );
 
-		const importBtn = screen.getByRole( 'button', { name: /Import Settings/i } );
+		const importBtn = screen.getByRole( 'button', {
+			name: /Import Settings/i,
+		} );
 
-        // Button should not be disabled after file selection
-        expect(importBtn).not.toBeDisabled();
+		// Button should not be disabled after file selection
+		expect( importBtn ).not.toBeDisabled();
 
-        // Mock FileReader
-        const mockFileReader = {
-            readAsText: jest.fn(),
-            result: '{"test":"value"}',
-            onload: null,
-            onerror: null,
-            onabort: null
-        };
-        jest.spyOn(window, 'FileReader').mockImplementation(() => mockFileReader);
+		// Mock FileReader
+		const mockFileReader = {
+			readAsText: jest.fn(),
+			result: '{"test":"value"}',
+			onload: null,
+			onerror: null,
+			onabort: null,
+		};
+		jest.spyOn( window, 'FileReader' ).mockImplementation(
+			() => mockFileReader
+		);
 
-        fireEvent.click( importBtn );
+		fireEvent.click( importBtn );
 
-        // Modal is open, click confirm
-        const confirmBtn = screen.getByRole('button', { name: /Confirm/i });
-        fireEvent.click(confirmBtn);
+		// Modal is open, click confirm
+		const confirmBtn = screen.getByRole( 'button', { name: /Confirm/i } );
+		fireEvent.click( confirmBtn );
 
-        // Simulate onload
-        act(() => {
-            mockFileReader.onload({ target: { result: mockFileReader.result } });
-        });
+		// Simulate onload
+		act( () => {
+			mockFileReader.onload( {
+				target: { result: mockFileReader.result },
+			} );
+		} );
 
 		await waitFor( () => {
 			expect( apiCall ).toHaveBeenCalledWith( 'import_settings', {
 				action: 'import_settings',
 				settings: { test: 'value' },
 			} );
-			expect( screen.getByText( 'File imported successfully' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'File imported successfully' )
+			).toBeInTheDocument();
 		} );
 	} );
 
-    it( 'handles import error with invalid JSON', async () => {
-		render( <PluginSetting options={{}} /> );
+	it( 'handles import error with invalid JSON', async () => {
+		render( <PluginSetting options={ {} } /> );
 
-		const file = new File( [ 'INVALID_JSON' ], 'settings.json', { type: 'application/json' } );
+		const file = new File( [ 'INVALID_JSON' ], 'settings.json', {
+			type: 'application/json',
+		} );
 		const input = screen.getByLabelText( /Select configuration file/i );
 
 		fireEvent.change( input, { target: { files: [ file ] } } );
 
-		const importBtn = screen.getByRole( 'button', { name: /Import Settings/i } );
+		const importBtn = screen.getByRole( 'button', {
+			name: /Import Settings/i,
+		} );
 
-        // Mock FileReader
-        const mockFileReader = {
-            readAsText: jest.fn(),
-            result: 'INVALID_JSON',
-            onload: null,
-            onerror: null,
-            onabort: null
-        };
-        jest.spyOn(window, 'FileReader').mockImplementation(() => mockFileReader);
+		// Mock FileReader
+		const mockFileReader = {
+			readAsText: jest.fn(),
+			result: 'INVALID_JSON',
+			onload: null,
+			onerror: null,
+			onabort: null,
+		};
+		jest.spyOn( window, 'FileReader' ).mockImplementation(
+			() => mockFileReader
+		);
 
-        fireEvent.click( importBtn );
+		fireEvent.click( importBtn );
 
-        // Modal is open, click confirm
-        const confirmBtn = screen.getByRole('button', { name: /Confirm/i });
-        fireEvent.click(confirmBtn);
+		// Modal is open, click confirm
+		const confirmBtn = screen.getByRole( 'button', { name: /Confirm/i } );
+		fireEvent.click( confirmBtn );
 
-        // Simulate onload with invalid JSON
-        act(() => {
-            mockFileReader.onload({ target: { result: mockFileReader.result } });
-        });
+		// Simulate onload with invalid JSON
+		act( () => {
+			mockFileReader.onload( {
+				target: { result: mockFileReader.result },
+			} );
+		} );
 
 		await waitFor( () => {
-			expect( screen.getByText( 'Invalid file format. Please select a valid JSON file.' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					'Invalid file format. Please select a valid JSON file.'
+				)
+			).toBeInTheDocument();
 		} );
 	} );
 
-    it( 'handles FileReader error during import', async () => {
-		render( <PluginSetting options={{}} /> );
+	it( 'handles FileReader error during import', async () => {
+		render( <PluginSetting options={ {} } /> );
 
-		const file = new File( [ '{"test":"value"}' ], 'settings.json', { type: 'application/json' } );
+		const file = new File( [ '{"test":"value"}' ], 'settings.json', {
+			type: 'application/json',
+		} );
 		const input = screen.getByLabelText( /Select configuration file/i );
 
 		fireEvent.change( input, { target: { files: [ file ] } } );
 
-		const importBtn = screen.getByRole( 'button', { name: /Import Settings/i } );
+		const importBtn = screen.getByRole( 'button', {
+			name: /Import Settings/i,
+		} );
 
-        // Mock FileReader
-        const mockFileReader = {
-            readAsText: jest.fn(),
-            onload: null,
-            onerror: null,
-            onabort: null
-        };
-        jest.spyOn(window, 'FileReader').mockImplementation(() => mockFileReader);
+		// Mock FileReader
+		const mockFileReader = {
+			readAsText: jest.fn(),
+			onload: null,
+			onerror: null,
+			onabort: null,
+		};
+		jest.spyOn( window, 'FileReader' ).mockImplementation(
+			() => mockFileReader
+		);
 
-        fireEvent.click( importBtn );
+		fireEvent.click( importBtn );
 
-        // Modal is open, click confirm
-        const confirmBtn = screen.getByRole('button', { name: /Confirm/i });
-        fireEvent.click(confirmBtn);
+		// Modal is open, click confirm
+		const confirmBtn = screen.getByRole( 'button', { name: /Confirm/i } );
+		fireEvent.click( confirmBtn );
 
-        // Simulate onerror
-        act(() => {
-            mockFileReader.onerror();
-        });
+		// Simulate onerror
+		act( () => {
+			mockFileReader.onerror();
+		} );
 
 		await waitFor( () => {
-			expect( screen.getByText( 'Error reading file' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Error reading file' )
+			).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/src/components/__tests__/PluginSetting.test.js
+++ b/src/components/__tests__/PluginSetting.test.js
@@ -1,0 +1,256 @@
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+// eslint-disable-next-line import/no-extraneous-dependencies -- React is required for JSX rendering in tests
+import React from 'react';
+import PluginSetting from '../PluginSetting';
+
+jest.mock( '../../lib/apiRequest', () => ( {
+	apiCall: jest.fn(),
+	fetchRecentActivities: jest.fn(),
+} ) );
+
+import { apiCall, fetchRecentActivities } from '../../lib/apiRequest';
+
+describe( 'PluginSetting Component', () => {
+	beforeEach( () => {
+		global.wppoSettings = {
+			settings: {
+				performance_audit: {},
+			},
+			performance_audit: {},
+		};
+		global.URL.createObjectURL = jest.fn();
+		global.URL.revokeObjectURL = jest.fn();
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the component and its main sections', () => {
+		render( <PluginSetting options={{}} /> );
+
+		expect( screen.getByText( 'Optimization Activity Log' ) ).toBeInTheDocument();
+		expect( screen.getAllByText( 'Google PageSpeed API Key' ).length ).toBeGreaterThan(0);
+		expect( screen.getByText( 'Export Configuration' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Import Configuration' ) ).toBeInTheDocument();
+	} );
+
+	it( 'loads and displays activity logs', async () => {
+		fetchRecentActivities.mockResolvedValueOnce( {
+			activities: [ { activity: 'Cache cleared successfully.' } ],
+			current_page: 1,
+			total_pages: 1,
+		} );
+
+		render( <PluginSetting options={{}} /> );
+
+		const loadLogBtn = screen.getByRole( 'button', { name: /Load Activity Log/i } );
+		fireEvent.click( loadLogBtn );
+
+		await waitFor( () => {
+			expect( fetchRecentActivities ).toHaveBeenCalledWith( 1 );
+			expect( screen.getByText( 'Cache cleared successfully.' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'handles activity log load error gracefully', async () => {
+		fetchRecentActivities.mockRejectedValueOnce( new Error( 'Failed to fetch logs' ) );
+        const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		render( <PluginSetting options={{}} /> );
+
+		const loadLogBtn = screen.getByRole( 'button', { name: /Load Activity Log/i } );
+		fireEvent.click( loadLogBtn );
+
+		await waitFor( () => {
+			expect( fetchRecentActivities ).toHaveBeenCalledWith( 1 );
+			expect( screen.getByText( 'Failed to fetch logs' ) ).toBeInTheDocument();
+		} );
+
+        consoleSpy.mockRestore();
+	} );
+
+	it( 'updates and saves Google PageSpeed API Key successfully', async () => {
+		apiCall.mockResolvedValueOnce( { success: true } );
+
+		render( <PluginSetting options={{}} /> );
+
+		const input = screen.getByLabelText( 'Google PageSpeed API Key' );
+		fireEvent.change( input, { target: { value: 'NEW_API_KEY_123' } } );
+
+		const saveBtn = screen.getByRole( 'button', { name: /Save Settings/i } );
+		fireEvent.click( saveBtn );
+
+		await waitFor( () => {
+			expect( apiCall ).toHaveBeenCalledWith( 'update_settings', {
+				tab: 'performance_audit',
+				settings: { pagespeed_api_key: 'NEW_API_KEY_123' },
+			} );
+			expect( screen.getByText( 'API key saved.' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'handles error when saving Google PageSpeed API Key', async () => {
+		apiCall.mockResolvedValueOnce( { success: false, message: 'Invalid API key.' } );
+
+		render( <PluginSetting options={{}} /> );
+
+		const input = screen.getByLabelText( 'Google PageSpeed API Key' );
+		fireEvent.change( input, { target: { value: 'INVALID_API_KEY' } } );
+
+		const saveBtn = screen.getByRole( 'button', { name: /Save Settings/i } );
+		fireEvent.click( saveBtn );
+
+		await waitFor( () => {
+			expect( apiCall ).toHaveBeenCalledWith( 'update_settings', expect.any(Object) );
+			expect( screen.getByText( 'Invalid API key.' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'exports settings correctly', () => {
+        const originalCreateElement = document.createElement.bind(document);
+		const createElementSpy = jest.spyOn( document, 'createElement' );
+		const mockAnchor = {
+            nodeType: 1,
+            setAttribute: jest.fn(),
+            click: jest.fn(),
+            href: '',
+            download: ''
+        };
+		createElementSpy.mockImplementation( ( tag ) => {
+			if ( tag === 'a' ) return mockAnchor;
+			return originalCreateElement( tag );
+		} );
+
+		render( <PluginSetting options={{ performance_audit: { pagespeed_api_key: 'SUPER_SECRET' } }} /> );
+
+		const exportBtn = screen.getByRole( 'button', { name: /Export Settings/i } );
+		fireEvent.click( exportBtn );
+
+		expect( mockAnchor.click ).toHaveBeenCalled();
+		expect( mockAnchor.download ).toMatch( /plugin-settings_.*\.json/ );
+
+		createElementSpy.mockRestore();
+	} );
+
+	it( 'disables import button when no file is selected', () => {
+		render( <PluginSetting options={{}} /> );
+
+		const importBtn = screen.getByRole( 'button', { name: /Import Settings/i } );
+		expect(importBtn).toBeDisabled();
+	} );
+
+	it( 'imports settings successfully', async () => {
+		apiCall.mockResolvedValueOnce( { success: true, message: 'File imported successfully' } );
+
+		render( <PluginSetting options={{}} /> );
+
+		const file = new File( [ '{"test":"value"}' ], 'settings.json', { type: 'application/json' } );
+		const input = screen.getByLabelText( /Select configuration file/i );
+
+		fireEvent.change( input, { target: { files: [ file ] } } );
+
+		const importBtn = screen.getByRole( 'button', { name: /Import Settings/i } );
+
+        // Button should not be disabled after file selection
+        expect(importBtn).not.toBeDisabled();
+
+        // Mock FileReader
+        const mockFileReader = {
+            readAsText: jest.fn(),
+            result: '{"test":"value"}',
+            onload: null,
+            onerror: null,
+            onabort: null
+        };
+        jest.spyOn(window, 'FileReader').mockImplementation(() => mockFileReader);
+
+        fireEvent.click( importBtn );
+
+        // Modal is open, click confirm
+        const confirmBtn = screen.getByRole('button', { name: /Confirm/i });
+        fireEvent.click(confirmBtn);
+
+        // Simulate onload
+        act(() => {
+            mockFileReader.onload({ target: { result: mockFileReader.result } });
+        });
+
+		await waitFor( () => {
+			expect( apiCall ).toHaveBeenCalledWith( 'import_settings', {
+				action: 'import_settings',
+				settings: { test: 'value' },
+			} );
+			expect( screen.getByText( 'File imported successfully' ) ).toBeInTheDocument();
+		} );
+	} );
+
+    it( 'handles import error with invalid JSON', async () => {
+		render( <PluginSetting options={{}} /> );
+
+		const file = new File( [ 'INVALID_JSON' ], 'settings.json', { type: 'application/json' } );
+		const input = screen.getByLabelText( /Select configuration file/i );
+
+		fireEvent.change( input, { target: { files: [ file ] } } );
+
+		const importBtn = screen.getByRole( 'button', { name: /Import Settings/i } );
+
+        // Mock FileReader
+        const mockFileReader = {
+            readAsText: jest.fn(),
+            result: 'INVALID_JSON',
+            onload: null,
+            onerror: null,
+            onabort: null
+        };
+        jest.spyOn(window, 'FileReader').mockImplementation(() => mockFileReader);
+
+        fireEvent.click( importBtn );
+
+        // Modal is open, click confirm
+        const confirmBtn = screen.getByRole('button', { name: /Confirm/i });
+        fireEvent.click(confirmBtn);
+
+        // Simulate onload with invalid JSON
+        act(() => {
+            mockFileReader.onload({ target: { result: mockFileReader.result } });
+        });
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Invalid file format. Please select a valid JSON file.' ) ).toBeInTheDocument();
+		} );
+	} );
+
+    it( 'handles FileReader error during import', async () => {
+		render( <PluginSetting options={{}} /> );
+
+		const file = new File( [ '{"test":"value"}' ], 'settings.json', { type: 'application/json' } );
+		const input = screen.getByLabelText( /Select configuration file/i );
+
+		fireEvent.change( input, { target: { files: [ file ] } } );
+
+		const importBtn = screen.getByRole( 'button', { name: /Import Settings/i } );
+
+        // Mock FileReader
+        const mockFileReader = {
+            readAsText: jest.fn(),
+            onload: null,
+            onerror: null,
+            onabort: null
+        };
+        jest.spyOn(window, 'FileReader').mockImplementation(() => mockFileReader);
+
+        fireEvent.click( importBtn );
+
+        // Modal is open, click confirm
+        const confirmBtn = screen.getByRole('button', { name: /Confirm/i });
+        fireEvent.click(confirmBtn);
+
+        // Simulate onerror
+        act(() => {
+            mockFileReader.onerror();
+        });
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Error reading file' ) ).toBeInTheDocument();
+		} );
+	} );
+} );


### PR DESCRIPTION
💡 Gap: The `PluginSetting` component in `src/components/PluginSetting.js` (which handles sensitive operations like exporting/importing configuration, saving API keys, and displaying logs) was completely untested.

🎯 Coverage: Added unit tests for:
- Rendering the main sections correctly.
- Successfully fetching and displaying activity logs.
- Handling activity log API failures.
- Saving Google PageSpeed API keys (success and failure paths).
- Exporting settings files (mocking `document.createElement('a')`).
- Importing settings via `FileReader` (success, invalid JSON, and read abort/error paths).

📊 Tools Used: `@testing-library/react`, Jest. Mocked internal `apiRequest` and browser API (`FileReader`, `document.createElement`).

---
*PR created automatically by Jules for task [10723207123860945836](https://jules.google.com/task/10723207123860945836) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader coverage for settings management, including loading recent activity, saving API settings, exporting/importing settings, and handling error cases.
  * Improved confidence in download and file-import flows, with checks for success, invalid input, and read failures.

* **Documentation**
  * Added a new QA note documenting a previously encountered test issue and the related fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->