### PR TITLE
🚔 Warden: [Code Quality Improvement] Fix inefficient cron loops and nested logic

### DIFF
--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -318,14 +318,13 @@ class Cron {
 			$images = $img_info['pending']['avif'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
+				++$counter;
 			}
 		}
 
@@ -333,14 +332,13 @@ class Cron {
 			$images = $img_info['pending']['webp'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
+				++$counter;
 			}
 		}
 	}


### PR DESCRIPTION
### 💡 What:
Refactored the `img_convert_cron()` batch processing loop in `includes/class-cron.php`. Removed the unnecessary `if (!empty($images))` check and implemented a guard clause using `break` to exit early when the batch limit is met.

### 🎯 Why:
The original loops were nested too deeply (`if format` -> `if !empty` -> `foreach` -> `if counter`). The `!empty()` check was completely redundant since `foreach` gracefully handles empty arrays. Additionally, the original `$counter <= $batch_size` check inside the `foreach` meant the loop would continue running and iterating through the entire `$images` array, executing `++$counter` uselessly even after the batch limit was met.

### 🚜 How:
1. Removed `if ( ! empty( $images ) )`.
2. Converted the nested loop conditional into an early return: `if ( $counter >= $batch_size ) { break; }`.
3. Moved `++$counter` outside of the conditional check to correctly track the converted images.

---
*PR created automatically by Jules for task [876699421488014035](https://jules.google.com/task/876699421488014035) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background image conversion batching so queued images are processed more consistently for AVIF and WebP formats.
  * Prevented batch runs from relying on empty/non-empty checks, which helps ensure pending items are handled up to the configured limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->