### PR TITLE
⚡ Bolt: [performance improvement] Add early break to image conversion batch loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,7 @@
 ## 2025-01-22 - WPCS Error Suppression
 **Learning:** WordPress Coding Standards (WPCS) strongly discourages using the error suppression operator (`@`) before functions like `fopen()`. While it suppresses warnings when a file doesn't exist, it is better to rely on `file_exists()` before opening or catch exceptions.
 **Action:** Never use `@fopen()`. Rely on `file_exists()` and standard `$handle = fopen(...)` with a falsy check, and use `// phpcs:ignore` annotations to bypass strict file system rules.
+## 2025-01-22 - Infinite Loop Risk in Batch Processing Arrays
+
+**Learning:** Iterating over large arrays using a loop (like `foreach`) for batch processing can result in the entire array being processed if an early exit condition is not met or incorrectly placed. This is especially true if a limit check is placed *after* the increment or process logic. If the batch size is very small (or 0), processing might still occur.
+**Action:** When implementing batch size limits in loops, place the condition (e.g. `if ( $counter >= $batch_size ) { break; }`) at the very beginning of the loop block, before incrementing the counter or processing the item, to guarantee the batch size is strictly respected and to avoid processing logic execution.

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -320,11 +320,13 @@ class Cron {
 			$counter = 0;
 			if ( ! empty( $images ) ) {
 				foreach ( $images as $img ) {
+					if ( $counter >= $batch_size ) {
+						break;
+					}
+
 					++$counter;
 
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+					$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
 				}
 			}
 		}
@@ -335,11 +337,13 @@ class Cron {
 			$counter = 0;
 			if ( ! empty( $images ) ) {
 				foreach ( $images as $img ) {
+					if ( $counter >= $batch_size ) {
+						break;
+					}
+
 					++$counter;
 
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+					$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
 				}
 			}
 		}


### PR DESCRIPTION
💡 What: Added an early `break` statement at the beginning of the loops in the `img_convert_cron` function inside `includes/class-cron.php`.
🎯 Why: Without the early break, the loop would continue to iterate through potentially thousands of remaining `$images` items even after the `$batch_size` limit was reached. This wasted CPU cycles unnecessarily during cron job processing.
📊 Impact: Reduces CPU and memory usage by terminating the loop immediately after the batch limit is hit, preventing N iterations (where N is the number of remaining unprocessed images).
🔬 Measurement: Verify the cron job respects the batch size limit properly and uses less processing time when large image sets are pending conversion.

---
*PR created automatically by Jules for task [9527612820986833425](https://jules.google.com/task/9527612820986833425) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image conversion batching so each cron run stops at the intended limit, avoiding off-by-one processing behavior for both AVIF and WebP conversions.
* **Documentation**
  * Added a note describing a best practice for preventing infinite loops when processing items in batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->