### PR TITLE
🚜 Warden: [Code Quality Improvement] Refactor image conversion cron batch logic

### DIFF
--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -318,14 +318,13 @@ class Cron {
 			$images = $img_info['pending']['avif'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
+				++$counter;
 			}
 		}
 
@@ -333,14 +332,13 @@ class Cron {
 			$images = $img_info['pending']['webp'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
+				++$counter;
 			}
 		}
 	}


### PR DESCRIPTION
### 💡 What:
Refactored `img_convert_cron()` inside `includes/class-cron.php`. Removed unnecessary nested conditional wrappers `if (!empty($images))` around `foreach` blocks, and implemented an early `break` inside the iteration loop instead of wrapping the core conversion logic inside `if ($counter <= $batch_size)`.

### 🎯 Why:
The previous implementation used deeply nested statements and checked the `$counter` value repeatedly even after exceeding the batch limit. This refactor applies the 'Single Responsibility Principle' and 'Early Returns' concepts to flatten the logic. Moving the check to the beginning of the loop ensures that if a user has configured a batch size of `0` (or after reaching the batch limit), the function avoids continuing iteration and evaluating nested constraints. 

### 🧹 How:
- Changed `foreach` wrapper conditions to utilize the inherently safe nature of iterating empty arrays in PHP.
- Inserted `if ($counter >= $batch_size) { break; }` at the top of the iterations.
- Placed `$counter++` after the execution logic for cleaner incremental tracking.

---
*PR created automatically by Jules for task [18377507012327316943](https://jules.google.com/task/18377507012327316943) started by @nilesh32236*