### PR TITLE
🔬 Inspector: ConfirmDialog Focus Trap Verification

### DIFF
--- a/.jules/inspector.md
+++ b/.jules/inspector.md
@@ -30,3 +30,8 @@
 **Bug/Gap:** Some React UI components had uncovered lines handling edge cases such as rendering fallback components or API responses with 'success: false' rather than network errors.
 **Root Cause:** Component test coverage lacked thorough assertions for alternative code paths.
 **Test Added:** Implemented extensive frontend unit testing coverage using Jest + RTL to test these sad paths for SystemInfo and DatabaseCleanup components. Added mock assertions, timeout delays mocking using jest.useFakeTimers and explicit DOM interaction testing for React ConfirmDialog component.
+
+## 2024-07-03 - Focus Trap Coverage Gap
+**Bug/Gap:** The focus trap logic within `ConfirmDialog.js` `handleKeyDown` function was missing assertions in tests. The original tests simulated `Tab` and `Shift+Tab` keystrokes but didn't verify if the active element moved as expected to the boundaries of the dialog.
+**Root Cause:** Insufficient strictness in the original frontend test suite; mimicking an event doesn't confirm its side effects.
+**Test Added:** Added explicit assertions using `jest.spyOn(element, 'focus')` and verifying `.toHaveBeenCalled()` when `Tab` or `Shift+Tab` is triggered on the dialog focus boundaries in `ConfirmDialog.test.js`.

--- a/src/components/common/__tests__/ConfirmDialog.test.js
+++ b/src/components/common/__tests__/ConfirmDialog.test.js
@@ -84,6 +84,10 @@ describe( 'ConfirmDialog', () => {
 		const first = focusableElements[ 0 ];
 		const last = focusableElements[ focusableElements.length - 1 ];
 
+		// Spies for focus
+		const firstFocusSpy = jest.spyOn( first, 'focus' );
+		const lastFocusSpy = jest.spyOn( last, 'focus' );
+
 		// Mock activeElement on document
 		Object.defineProperty( document, 'activeElement', {
 			value: last,
@@ -92,6 +96,8 @@ describe( 'ConfirmDialog', () => {
 
 		// Simulate Tab keypress on dialog when activeElement is last
 		fireEvent.keyDown( dialog, { key: 'Tab', code: 'Tab' } );
+
+		expect( firstFocusSpy ).toHaveBeenCalled();
 
 		// Simulate Shift+Tab on dialog when activeElement is first
 		Object.defineProperty( document, 'activeElement', {
@@ -103,6 +109,8 @@ describe( 'ConfirmDialog', () => {
 			code: 'Tab',
 			shiftKey: true,
 		} );
+
+		expect( lastFocusSpy ).toHaveBeenCalled();
 	} );
 
 	it( 'handles tab key logic with no shift correctly', async () => {


### PR DESCRIPTION
💡 Gap: The `ConfirmDialog` React component's focus trap logic (`handleKeyDown`) had a unit test that simulated `Tab` and `Shift+Tab` events but lacked any assertions to verify if the `focus` method was actually called on the target elements, leaving the logic unverified.
🎯 Coverage: Added assertions utilizing `jest.spyOn(element, 'focus')` to guarantee the focus is wrapped correctly between the first and last element of the dialog boundaries when tabbing.
📊 Tools Used: Ran Jest coverage tests (`npm run test -- --coverage src/components/common/__tests__/ConfirmDialog.test.js`) to expose the missing logic branch verification and then ran the full `npm run test` suite and `npm run lint:js` to verify regressions.

---
*PR created automatically by Jules for task [11289566557486577076](https://jules.google.com/task/11289566557486577076) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage for dialog keyboard navigation, ensuring focus correctly wraps with `Tab` and `Shift+Tab`.

* **Documentation**
  * Added an internal QA note describing the focus-trap coverage gap and the new checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->