### PR TITLE
🚔 Warden: [Code Quality Improvement]

### DIFF
--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -318,14 +318,13 @@ class Cron {
 			$images = $img_info['pending']['avif'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
+				++$counter;
 			}
 		}
 
@@ -333,14 +332,13 @@ class Cron {
 			$images = $img_info['pending']['webp'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
+				++$counter;
 			}
 		}
 	}


### PR DESCRIPTION
**What was cleaned up:**
Refactored the `img_convert_cron` method in `includes/class-cron.php`. Specifically, removed the redundant `if ( ! empty( $images ) )` wrappers around the `foreach` loops, and moved the batch size limit check (`if ( $counter >= $batch_size )`) to the beginning of the loop body with a `break` statement.

**Why it was messy:**
The original code checked if the array was empty before looping (which is unnecessary as `foreach` handles empty arrays gracefully). Also, the original loop iterated through *all* elements in the array even after the `$batch_size` limit was reached, merely skipping the processing logic.

**How the new structure improves readability (and performance):**
Flattening the nested conditionals reduces visual complexity. By introducing an early `break` condition, the loop now exits immediately when the batch limit is reached, which prevents iterating over the rest of the array when there's no work left to do.

---
*PR created automatically by Jules for task [7042786040152794870](https://jules.google.com/task/7042786040152794870) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image conversion processing so pending images are handled more reliably in smaller batches.
  * Prevents extra items from being processed once the batch limit is reached, helping keep conversion runs consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->