### PR TITLE
⚡ Bolt: Optimize cron batching loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,7 @@
 ## 2025-01-22 - WPCS Error Suppression
 **Learning:** WordPress Coding Standards (WPCS) strongly discourages using the error suppression operator (`@`) before functions like `fopen()`. While it suppresses warnings when a file doesn't exist, it is better to rely on `file_exists()` before opening or catch exceptions.
 **Action:** Never use `@fopen()`. Rely on `file_exists()` and standard `$handle = fopen(...)` with a falsy check, and use `// phpcs:ignore` annotations to bypass strict file system rules.
+## 2025-01-22 - Early breaks in Batch Processing Loops
+
+**Learning:** Iterating over large arrays of pending jobs (e.g. image conversions) without an early break statement forces PHP to evaluate every item, even after the designated `$batch_size` has been reached, causing unnecessary CPU cycles.
+**Action:** Always include an early `break` statement at the very beginning of the loop body (e.g. `if ( $counter >= $batch_size ) { break; }`) when performing batch processing over a subset of a larger array.

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -320,11 +320,13 @@ class Cron {
 			$counter = 0;
 			if ( ! empty( $images ) ) {
 				foreach ( $images as $img ) {
+					if ( $counter >= $batch_size ) {
+						break;
+					}
+
 					++$counter;
 
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+					$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
 				}
 			}
 		}
@@ -335,11 +337,13 @@ class Cron {
 			$counter = 0;
 			if ( ! empty( $images ) ) {
 				foreach ( $images as $img ) {
+					if ( $counter >= $batch_size ) {
+						break;
+					}
+
 					++$counter;
 
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+					$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
 				}
 			}
 		}


### PR DESCRIPTION
💡 What:
Added early `break` statements to the `foreach` loops in the `img_convert_cron` method in `includes/class-cron.php`.

🎯 Why:
The cron job handles batch processing of image conversions (AVIF and WebP). While it was correctly restricting the actual conversion (`convert_image`) to the first `$batch_size` items, the `foreach` loop itself would still needlessly iterate through the entire `$images` array even after the batch limit was met, wasting CPU cycles and memory overhead on large arrays of pending images.

📊 Impact:
Saves potentially thousands of unnecessary loop iterations during image conversion cron runs when the pending image queue is large, significantly reducing the CPU overhead of the background task.

🔬 Measurement:
1. Verify `includes/class-cron.php` contains the `if ( $counter >= $batch_size ) { break; }` check at the start of both `foreach` loops in `img_convert_cron`.
2. Schedule and run the image conversion cron with a queue larger than the batch size (e.g., > 50) and observe it breaks early exactly at the batch limit.

---
*PR created automatically by Jules for task [13874565078875199830](https://jules.google.com/task/13874565078875199830) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch image conversions now stop at the configured limit, preventing extra AVIF/WebP conversions in a single run.
  * Processing is more consistent when large image batches are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->