### PR TITLE
🚔 Warden: [Code Quality Improvement]

### DIFF
--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -318,14 +318,13 @@ class Cron {
 			$images = $img_info['pending']['avif'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
+				++$counter;
 			}
 		}
 
@@ -333,14 +332,13 @@ class Cron {
 			$images = $img_info['pending']['webp'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
+				++$counter;
 			}
 		}
 	}


### PR DESCRIPTION
**What was cleaned up:** 
Refactored the `img_convert_cron` method in `includes/class-cron.php`. Specifically, removed unnecessary `if ( ! empty( $images ) )` wrappers around the `foreach` loops (as `foreach` handles empty arrays safely), and replaced the `if ( $counter <= $batch_size )` condition inside the loop with an early return (`break`) at the very beginning of the loop body.

**Why it was messy:** 
The original code added an unnecessary level of nesting with the `! empty()` check, and more importantly, it allowed the `foreach` loop to continue iterating over the remainder of the `$images` array even after the batch limit had been reached, simply skipping the conversion logic but still executing loop cycles.

**How the new structure improves readability:** 
The code is flatter and easier to follow without the redundant array empty check. Placing the batch limit check as a guard clause with a `break` at the top of the loop body explicitly communicates the batching logic and ensures the function stops processing entirely once the batch limit is hit, improving both clarity and performance.

---
*PR created automatically by Jules for task [3884041194526749189](https://jules.google.com/task/3884041194526749189) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how pending image conversions are processed in batches.
  * Made batch limits more consistent when handling different image formats.
  * This should help conversion jobs stop at the expected batch size and behave more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->