### PR TITLE
🚔 Warden: [Code Quality Improvement]

### DIFF
--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -318,14 +318,13 @@ class Cron {
 			$images = $img_info['pending']['avif'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
+				++$counter;
 			}
 		}
 
@@ -333,14 +332,13 @@ class Cron {
 			$images = $img_info['pending']['webp'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
+				++$counter;
 			}
 		}
 	}


### PR DESCRIPTION
### What was cleaned up
The `img_convert_cron` method in `includes/class-cron.php` contained a redundant `if ( ! empty( $images ) )` check around a `foreach` loop. Additionally, the loop iterated through all pending images even after reaching the configured batch size limit, skipping the conversion but still executing the loop.

### Why it was messy
- `foreach` loops in PHP naturally handle empty arrays, making the `! empty()` check unnecessary boilerplate.
- Iterating through hundreds or thousands of pending images when the batch limit (e.g., 50) has already been reached is a waste of CPU cycles and memory.

### How the new structure improves readability
- The redundant `! empty()` check was removed, flattening the code structure.
- An explicit early exit (`break`) was introduced at the start of the `foreach` loop body to immediately stop execution when the `$batch_size` limit is reached, making the performance optimization clear and explicit.

---
*PR created automatically by Jules for task [3737784032228237306](https://jules.google.com/task/3737784032228237306) started by @nilesh32236*