### PR TITLE
🚔 Warden: [Code Quality Improvement] Optimize cron batch processing loop

### DIFF
--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -318,14 +318,13 @@ class Cron {
 			$images = $img_info['pending']['avif'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
+				++$counter;
 			}
 		}
 
@@ -333,14 +332,13 @@ class Cron {
 			$images = $img_info['pending']['webp'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
+				++$counter;
 			}
 		}
 	}


### PR DESCRIPTION
**🚔 Warden: Code Quality Improvement**

**What:**
Refactored the image conversion batch processing loops in the `img_convert_cron()` method (`includes/class-cron.php`).

**Why:**
The previous code iterated over the entire `$images` array, evaluating `if ( $counter <= $batch_size )` on every single pass, even after the batch limit had been reached. If the array had 10,000 items and a batch size of 50, the code would pointlessly iterate 9,950 times doing nothing. It also wrapped the `foreach` loops in unnecessary `if ( ! empty( $images ) )` checks.

**How the new structure improves readability and performance:**
- **Readability:** Flattens nesting by removing the redundant `! empty()` check (since `foreach` safely handles empty arrays) and relying on a guard clause (`if ( $counter >= $batch_size ) { break; }`).
- **Performance:** Implements an early `break` statement inside the loop, preventing thousands of unnecessary iterations once the batch limit is hit.

---
*PR created automatically by Jules for task [13893113346180797909](https://jules.google.com/task/13893113346180797909) started by @nilesh32236*