### PR TITLE
🚔 Warden: Refactor `img_convert_cron` loop logic

### DIFF
--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -318,14 +318,14 @@ class Cron {
 			$images = $img_info['pending']['avif'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
+
+				++$counter;
 			}
 		}
 
@@ -333,14 +333,14 @@ class Cron {
 			$images = $img_info['pending']['webp'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
+
+				++$counter;
 			}
 		}
 	}


### PR DESCRIPTION
## What was cleaned up
In `includes/class-cron.php`, the `img_convert_cron()` method contained `foreach` loops that were wrapped in redundant `! empty( $images )` conditionals. Inside the loops, an `if` block conditionally executed the conversion only if the counter was below a certain threshold, meaning the loop still iterated unnecessarily through the rest of the array after the batch limit was reached.

## Why it was messy
- The `! empty()` checks around `foreach` are unnecessary, as `foreach` naturally skips execution if an array is empty. This adds unnecessary nesting.
- Allowing the loop to continue iterating over potentially large image arrays without performing any actions, just to check an unmet condition, is computationally wasteful.

## How the new structure improves readability
- The redundant `! empty()` wrapping has been removed, flattening the logic and making it cleaner.
- By introducing an early `break` statement at the top of the loop body (`if ( $counter >= $batch_size ) { break; }`), the intent is clearer (exiting when the batch size is hit), and execution stops immediately once the limit is reached, improving both readability and performance.

---
*PR created automatically by Jules for task [10493666755490345862](https://jules.google.com/task/10493666755490345862) started by @nilesh32236*