### PR TITLE
🔬 Inspector: UI component test improvements and sad path coverage

### DIFF
--- a/.jules/inspector.md
+++ b/.jules/inspector.md
@@ -30,3 +30,7 @@
 **Bug/Gap:** Some React UI components had uncovered lines handling edge cases such as rendering fallback components or API responses with 'success: false' rather than network errors.
 **Root Cause:** Component test coverage lacked thorough assertions for alternative code paths.
 **Test Added:** Implemented extensive frontend unit testing coverage using Jest + RTL to test these sad paths for SystemInfo and DatabaseCleanup components. Added mock assertions, timeout delays mocking using jest.useFakeTimers and explicit DOM interaction testing for React ConfirmDialog component.
+## $(date +%Y-%m-%d) - [JS Test Fix] Testing UI component in jsdom global events
+**Bug/Gap:** Focus trap tests in React components using `document.addEventListener` for keyboard navigation were not functioning properly in Jest because the `fireEvent.keyDown` was erroneously targeting the internal component `dialog` element rather than the `document` root.
+**Root Cause:** `ConfirmDialog.js` correctly binds the `keydown` event listener to `document`, but the Jest tests were dispatching the simulated keyboard events to the isolated `screen.getByRole('dialog')` wrapper, causing the listener to ignore the events. Additionally, focus assertions lacked strict spy interactions.
+**Test Added:** Updated the test to dispatch `fireEvent.keyDown` on `document` instead. Included rigorous `jest.spyOn(element, 'focus')` and `.toHaveBeenCalled()` checks to explicitly verify the focus logic without relying entirely on mocked `document.activeElement` states which can be brittle.

--- a/src/components/__tests__/DatabaseCleanup.test.js
+++ b/src/components/__tests__/DatabaseCleanup.test.js
@@ -448,4 +448,39 @@ describe( 'DatabaseCleanup Component', () => {
 			).toBeInTheDocument();
 		} );
 	} );
+
+	it( 'shows fallback error message with failures when cleanup API fails without a message', async () => {
+		apiCall.mockResolvedValueOnce( {
+			success: true,
+			data: { revisions: 10 },
+		} );
+
+		render( <DatabaseCleanup /> );
+
+		await waitFor( () => {
+			expect( screen.getAllByText( '10' )[ 0 ] ).toBeInTheDocument();
+		} );
+
+		// Setup the next API call for cleanup failing
+		apiCall.mockResolvedValueOnce( {
+			success: false,
+			data: { failures: { item1: 'error', item2: 'error' } },
+		} );
+
+		// Click clean button for revisions
+		const cleanButtons = screen.getAllByRole( 'button', {
+			name: /Clean/i,
+		} );
+		fireEvent.click( cleanButtons[ 0 ] );
+
+		// Confirm cleanup
+		const confirmButton = screen.getByRole( 'button', { name: 'Delete' } );
+		fireEvent.click( confirmButton );
+
+		await waitFor( () => {
+			expect(
+				screen.getByText( 'Cleanup failed. Failures: item1, item2' )
+			).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/src/components/__tests__/SystemInfo.test.js
+++ b/src/components/__tests__/SystemInfo.test.js
@@ -107,6 +107,49 @@ describe( 'SystemInfo Component', () => {
 		} );
 	} );
 
+	it( 'renders fallback error message on successful response with success false and no message', async () => {
+		fetchSystemInfo.mockResolvedValueOnce( {
+			success: false,
+		} );
+		render( <SystemInfo /> );
+
+		const loadButton = screen.getByRole( 'button', {
+			name: /load system info/i,
+		} );
+		fireEvent.click( loadButton );
+
+		await waitFor( () => {
+			expect(
+				screen.getByText(
+					'Failed to fetch system info. Please try again.'
+				)
+			).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders unknown keys as labels when no mapping is provided', async () => {
+		fetchSystemInfo.mockResolvedValueOnce( {
+			success: true,
+			data: {
+				php: { unknown_key: 'test_value' },
+				database: {},
+				wordpress: {},
+				server: {},
+			},
+		} );
+		render( <SystemInfo /> );
+
+		const loadButton = screen.getByRole( 'button', {
+			name: /load system info/i,
+		} );
+		fireEvent.click( loadButton );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'unknown_key' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'test_value' ) ).toBeInTheDocument();
+		} );
+	} );
+
 	it( 'renders error message on failure', async () => {
 		const consoleSpy = jest
 			.spyOn( console, 'error' )

--- a/src/components/common/__tests__/ConfirmDialog.test.js
+++ b/src/components/common/__tests__/ConfirmDialog.test.js
@@ -84,6 +84,9 @@ describe( 'ConfirmDialog', () => {
 		const first = focusableElements[ 0 ];
 		const last = focusableElements[ focusableElements.length - 1 ];
 
+		const focusFirstMock = jest.spyOn( first, 'focus' );
+		const focusLastMock = jest.spyOn( last, 'focus' );
+
 		// Mock activeElement on document
 		Object.defineProperty( document, 'activeElement', {
 			value: last,
@@ -91,18 +94,23 @@ describe( 'ConfirmDialog', () => {
 		} );
 
 		// Simulate Tab keypress on dialog when activeElement is last
-		fireEvent.keyDown( dialog, { key: 'Tab', code: 'Tab' } );
+		fireEvent.keyDown( document, { key: 'Tab', code: 'Tab' } );
+		expect( focusFirstMock ).toHaveBeenCalledTimes( 1 );
 
 		// Simulate Shift+Tab on dialog when activeElement is first
 		Object.defineProperty( document, 'activeElement', {
 			value: first,
 			writable: true,
 		} );
-		fireEvent.keyDown( dialog, {
+		fireEvent.keyDown( document, {
 			key: 'Tab',
 			code: 'Tab',
 			shiftKey: true,
 		} );
+		expect( focusLastMock ).toHaveBeenCalledTimes( 1 );
+
+		focusFirstMock.mockRestore();
+		focusLastMock.mockRestore();
 	} );
 
 	it( 'handles tab key logic with no shift correctly', async () => {
@@ -117,9 +125,7 @@ describe( 'ConfirmDialog', () => {
 			/>
 		);
 
-		const dialog = screen.getByRole( 'dialog' );
-
-		fireEvent.keyDown( dialog, {
+		fireEvent.keyDown( document, {
 			key: 'Tab',
 			code: 'Tab',
 			shiftKey: false,


### PR DESCRIPTION
💡 Gap: The ConfirmDialog focus trap tests were dispatching `keyDown` events to the isolated dialog element in jsdom rather than `document`, causing the bound listeners to ignore the events. Additionally, several sad-path error handling blocks in SystemInfo.js (lines 57, 84) and DatabaseCleanup.js (line 138-144) were untested.
🎯 Coverage: Fixed focus trap tests to properly assert element focus loops. Added fallback UI tests for missing payload labels or empty API error message strings. 
📊 Tools Used: Jest, React Testing Library, test coverage logs.

---
*PR created automatically by Jules for task [12554148840487315958](https://jules.google.com/task/12554148840487315958) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog keyboard navigation reliability so focus stays within confirmation dialogs.
  * Added clearer fallback error handling when cleanup or system info requests fail without a specific message.
  * Display now better handles unexpected system data by showing unmapped fields instead of hiding them.

* **Documentation**
  * Added a note describing the updated keyboard focus test coverage and error-handling expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->