### PR TITLE
🚔 Warden: Refactor image conversion cron loop to improve readability and performance

### DIFF
--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -318,14 +318,13 @@ class Cron {
 			$images = $img_info['pending']['avif'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ), 'avif' );
+				++$counter;
 			}
 		}
 
@@ -333,14 +332,13 @@ class Cron {
 			$images = $img_info['pending']['webp'] ?? array();
 
 			$counter = 0;
-			if ( ! empty( $images ) ) {
-				foreach ( $images as $img ) {
-					++$counter;
-
-					if ( $counter <= $batch_size ) {
-						$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
-					}
+			foreach ( $images as $img ) {
+				if ( $counter >= $batch_size ) {
+					break;
 				}
+
+				$img_converter->convert_image( wp_normalize_path( ABSPATH . $img ) );
+				++$counter;
 			}
 		}
 	}


### PR DESCRIPTION
**What was cleaned up:** 
Refactored the `img_convert_cron` function in `includes/class-cron.php`. 

**Why it was messy:** 
The original implementation needlessly iterated over the entire array of pending images, even after the `$batch_size` limit was reached. It was checking `if ( $counter <= $batch_size )` on every item, leading to wasted loop cycles. It also unnecessarily wrapped the `foreach` loops in `! empty()` checks.

**How the new structure improves readability:**
By utilizing an early `break` statement (`if ( $counter >= $batch_size ) { break; }`), the loop immediately exits once the batch quota is met, significantly improving performance and clarity. Furthermore, removing the redundant `! empty()` check reduces indentation and nesting, producing cleaner, standard code.

---
*PR created automatically by Jules for task [13962072949031648979](https://jules.google.com/task/13962072949031648979) started by @nilesh32236*