### PR TITLE
⚡ Bolt: [performance improvement] Cache CSS/JS minification checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,6 @@
 ## 2025-01-22 - WPCS Error Suppression
 **Learning:** WordPress Coding Standards (WPCS) strongly discourages using the error suppression operator (`@`) before functions like `fopen()`. While it suppresses warnings when a file doesn't exist, it is better to rely on `file_exists()` before opening or catch exceptions.
 **Action:** Never use `@fopen()`. Rely on `file_exists()` and standard `$handle = fopen(...)` with a falsy check, and use `// phpcs:ignore` annotations to bypass strict file system rules.
+## 2024-07-19 - Avoid repeated disk operations on non-minified assets
+**Learning:** `fopen()` and `fgets()` used to determine if CSS and JS assets are already minified are extremely expensive when executed repeatedly for assets without `.min` in the name, causing significant main thread blocking.
+**Action:** Use native Object Caching (`wp_cache_get` and `wp_cache_set`) based on the file content's `md5` and modification time to bypass file reads if the check was recently executed.

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -908,6 +908,14 @@ class Main {
 			return true;
 		}
 
+		// Cache the file line count check to avoid expensive fopen/fgets on every page load.
+		$cache_key = 'is_min_css_' . md5( $file_path . filemtime( $file_path ) );
+		$cached    = wp_cache_get( $cache_key, 'wppo_assets', false, $found );
+
+		if ( $found ) {
+			return (bool) $cached;
+		}
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 		$handle = fopen( $file_path, 'r' );
 		if ( ! $handle ) {
@@ -925,7 +933,10 @@ class Main {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		fclose( $handle );
 
-		return 10 >= $line_count;
+		$is_minified = 10 >= $line_count;
+		wp_cache_set( $cache_key, (int) $is_minified, 'wppo_assets' );
+
+		return $is_minified;
 	}
 
 	/**
@@ -949,6 +960,14 @@ class Main {
 			return true;
 		}
 
+		// Cache the file line count check to avoid expensive fopen/fgets on every page load.
+		$cache_key = 'is_min_js_' . md5( $file_path . filemtime( $file_path ) );
+		$cached    = wp_cache_get( $cache_key, 'wppo_assets', false, $found );
+
+		if ( $found ) {
+			return (bool) $cached;
+		}
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 		$handle = fopen( $file_path, 'r' );
 		if ( ! $handle ) {
@@ -966,6 +985,9 @@ class Main {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		fclose( $handle );
 
-		return 10 >= $line_count;
+		$is_minified = 10 >= $line_count;
+		wp_cache_set( $cache_key, (int) $is_minified, 'wppo_assets' );
+
+		return $is_minified;
 	}
 }


### PR DESCRIPTION
💡 What: The optimization implemented
Added WordPress Object Caching (`wp_cache_get` and `wp_cache_set`) to the `is_css_minified` and `is_js_minified` methods in `includes/class-main.php`.

🎯 Why: The performance problem it solves
Previously, for any CSS or JS file lacking `.min` in the name, the plugin used `fopen()` and `fgets()` to read the first 10 lines to determine if the asset was minified. This operation ran on every single page load for every single asset, blocking the main thread and causing massive I/O overhead.

📊 Impact: Expected performance improvement
Significantly reduces server I/O overhead and main thread blocking by skipping disk reads on every page load after the initial check.

🔬 Measurement: How to verify the improvement
Observe reduced load time and fewer disk I/O operations via Query Monitor or New Relic when enqueuing non-minified assets.

*Also addressed code review nitpicks:* Added inline comments explaining the optimization.

---
*PR created automatically by Jules for task [9726917209435869596](https://jules.google.com/task/9726917209435869596) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved asset processing by caching minification checks.
  * Reduced repeated file reads when determining whether CSS and JavaScript assets are minified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->