### PR TITLE
[Autofix] [Audit:security] 0 critical, 2 important, 4 minor

### DIFF
--- a/includes/class-image-optimisation.php
+++ b/includes/class-image-optimisation.php
@@ -1200,8 +1200,8 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 			preg_match( '/\bwidth=["\']?(\d+)["\']?/i', $img_attributes, $width_matches );
 			preg_match( '/\bheight=["\']?(\d+)["\']?/i', $img_attributes, $height_matches );
 
-			$width  = isset( $width_matches[1] ) ? $width_matches[1] : '100';
-			$height = isset( $height_matches[1] ) ? $height_matches[1] : '100';
+			$width  = isset( $width_matches[1] ) ? absint( $width_matches[1] ) : 100;
+			$height = isset( $height_matches[1] ) ? absint( $height_matches[1] ) : 100;
 
 			$svg_content = '<svg xmlns="http://www.w3.org/2000/svg" width="' . $width . '" height="' . $height . '" viewBox="0 0 ' . $width . ' ' . $height . '"><rect width="100%" height="100%" fill="#cfd4db" /></svg>';
 

--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -129,7 +129,7 @@ class Img_Converter {
 		$max_bytes = apply_filters( 'wppo_filesize_limit_bytes', 20 * 1024 * 1024 );
 		if ( filesize( $source_image ) > $max_bytes ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( sprintf( 'WPPO Error: Image filesize (%d bytes) exceeds limit (%d bytes) - %s', filesize( $source_image ), $max_bytes, $source_image ) );
+			error_log( sprintf( 'WPPO Error: Image filesize (%d bytes) exceeds limit (%d bytes) - %s', filesize( $source_image ), $max_bytes, str_replace( ABSPATH, '', $source_image ) ) );
 			$this->update_conversion_status( $source_image, 'failed', $format );
 			return false;
 		}
@@ -646,7 +646,8 @@ class Img_Converter {
 
 		// Only queue images that live inside wp-content/uploads.
 		if ( strpos( $normalized, $upload_dir ) !== 0 ) {
-			error_log( sprintf( 'WPPO: add_img_into_queue rejected path "%s" — not inside uploads directory.', $normalized ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( sprintf( 'WPPO: add_img_into_queue rejected path "%s" — not inside uploads directory.', str_replace( wp_normalize_path( ABSPATH ), '', $normalized ) ) );
 			return false;
 		}
 

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -498,12 +498,17 @@ class Main {
 		}
 
 		$asset_file = WPPO_PLUGIN_PATH . 'build/index.asset.php';
+		$resolved   = wp_normalize_path( realpath( $asset_file ) );
 
-		// Include the asset file to retrieve dependencies and version.
-		$asset_data = file_exists( $asset_file ) ? include $asset_file : array(
-			'dependencies' => array(),
-			'version'      => false,
-		);
+		// Validate the resolved path is within the plugin directory before including.
+		if ( false !== $resolved && strpos( $resolved, WPPO_PLUGIN_PATH ) === 0 ) {
+			$asset_data = require $resolved;
+		} else {
+			$asset_data = array(
+				'dependencies' => array(),
+				'version'      => false,
+			);
+		}
 
 		wp_enqueue_style( 'performance-optimisation-style', WPPO_PLUGIN_URL . 'build/style-index.css', array(), $asset_data['version'], 'all' );
 		wp_enqueue_script( 'performance-optimisation-script', WPPO_PLUGIN_URL . 'build/index.js', $asset_data['dependencies'], $asset_data['version'], true );

--- a/includes/class-pagespeed.php
+++ b/includes/class-pagespeed.php
@@ -118,7 +118,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Pagespeed' ) ) {
 			$request_url = $url;
 
 			// The Google PageSpeed API rejects localhost or non-public URLs.
-			if ( false !== strpos( $request_url, 'localhost' ) || false !== strpos( $request_url, '127.0.0.1' ) ) {
+			// Use wp_http_validate_url() for robust SSRF protection (rejects loopback,
+			// private/reserved IP ranges including IPv6, 0.0.0.0, 10.x, 172.16-31.x, 192.168.x).
+			if ( ! wp_http_validate_url( $request_url ) ) {
 				new Log( __( 'PageSpeed scan failed: local URL detected.', 'performance-optimisation' ) );
 				self::store_failure( $url, $strategy, 'PageSpeed cannot scan local or non-public URLs. Please use a public URL.' );
 				return;

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -244,7 +244,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Rest' ) ) {
 				} elseif ( is_numeric( $value ) ) {
 					$sanitized[ $safe_key ] = (int) $value;
 				} elseif ( stripos( $safe_key, 'api_key' ) !== false || stripos( $safe_key, 'password' ) !== false ) {
-					$sanitized[ $safe_key ] = sanitize_text_field( $value );
+					// Use wp_kses() to strip HTML tags and null bytes while preserving
+					// special characters (e.g. +, /, = in base64 keys, or special chars in passwords).
+					$sanitized[ $safe_key ] = wp_kses( $value, array() );
 				} elseif ( stripos( $safe_key, 'url' ) !== false || stripos( $safe_key, 'cdn' ) !== false || stripos( $safe_key, 'origin' ) !== false ) {
 					$sanitized[ $safe_key ] = esc_url_raw( $value );
 				} elseif ( stripos( $safe_key, 'exclude' ) !== false || stripos( $safe_key, 'preload' ) !== false || stripos( $safe_key, 'delay' ) !== false || stripos( $safe_key, 'list' ) !== false ) {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'nilesh/performance-optimisation',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => '166b5780aa545127cbebff96b35c0ee945536c8c',
+        'reference' => '67ff65071d34424ce2418cff3378c682392d4f81',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -40,7 +40,7 @@
         'nilesh/performance-optimisation' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => '166b5780aa545127cbebff96b35c0ee945536c8c',
+            'reference' => '67ff65071d34424ce2418cff3378c682392d4f81',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Fixes #322

<!-- audit-issue -->

## Audit: security

**Target directory:** `includes`
**Results:** 0 critical, 2 important, 4 minor

**Summary:** Audited includes/ (25 PHP files). Found 0 critical, 2 important, 4 minor issues. The codebase shows strong security posture: all 16 REST endpoints enforce manage_options + X-WP-Nonce, all user input is sanitized, SQL queries use $wpdb->prepare(), path traversal is blocked consistently, API keys are never hardcoded or exposed in JS globals, Redis passwords are excluded from on-disk config files, and SSRF is mitigated with host/scheme/URL validation.

### Findings

- **IMPORTANT** `includes/class-pagespeed.php:121` — Weak local URL detection in run_scan() — only checks for 'localhost' and '127.0.0.1' substring, missing IPv6 loopback ([::1]), other 127.x.x.x ranges, 0.0.0.0, and private IP ranges (10.x, 172.16-31.x, 192.168.x). An attacker with manage_options could queue a scan pointing to an internal service that mirrors a valid hostname.
  - *Fix:* Replace strpos checks with a more robust private-IP detection function such as filter_var($url, FILTER_VALIDATE_URL) + filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE), or use wp_http_validate_url() which already rejects private/reserved addresses (the REST endpoint already calls it — replicate that check here for defense-in-depth).
- **IMPORTANT** `includes/class-rest.php:247` — API key and password sanitization uses sanitize_text_field() which strips certain characters (HTML tags, null bytes, UTF-8 invalid sequences, line breaks). While most API keys are alphanumeric and survive, some services use base64-encoded keys that may include '+' or '/' characters, and passwords may include special characters that could be silently corrupted.
  - *Fix:* For API keys and passwords, consider using a less aggressive sanitizer that only strips null bytes and HTML (e.g., remove malicious characters but preserve the payload). A custom sanitizer or wp_kses with no allowed tags would be safer. For example: wp_kses($value, array()) or a function that strips only null bytes, UTF-8 malformed sequences, and control characters (excluding tab/newline if needed).
- **MINOR** `includes/class-img-converter.php:132` — error_log() called with filesystem path ($source_image) when an image exceeds the file size or dimension limit. This leaks the internal ABSPATH-relative filesystem layout to PHP error logs, which may be accessible via debug.log or server error logs.
  - *Fix:* Use a path-relative-to-ABSPATH representation (already available as the normalized relative path) instead of the full absolute path in error_log() calls. For example, use str_replace(ABSPATH, '', $source_image) to log only the relative path.
- **MINOR** `includes/class-img-converter.php:649` — error_log() called with full normalized filesystem path when add_img_into_queue() rejects a path outside uploads. Leaks internal directory structure to logs.
  - *Fix:* Log only the path relative to ABSPATH instead of the full absolute path.
- **MINOR** `includes/class-main.php:503` — Dynamic include of build/index.asset.php via file_exists() + include. While the path is constructed from the hardcoded WPPO_PLUGIN_PATH constant (not user input), the pattern of include on a runtime-computed path is risky if the constant or filesystem state is ever tampered with.
  - *Fix:* Use require_once instead of include to fail hard if the file is missing, and validate that the resolved path is within the plugin directory before including. Add a boundary check: $resolved = wp_normalize_path(realpath($asset_file)); if (strpos($resolved, WPPO_PLUGIN_PATH) === 0) { $asset_data = require $resolved; }
- **MINOR** `includes/class-image-optimisation.php:1206` — SVG placeholder markup constructed with string interpolation using width/height extracted via regex from img attributes. Although the regex only captures digits (\d+), the SVG XML content (including the placeholder fill color #cfd4db) is static. This is not exploitable but represents a pattern where dynamic content is embedded into XML-like strings.
  - *Fix:* Add absint() casts on the extracted width and height values as defense-in-depth: $width = isset($width_matches[1]) ? absint($width_matches[1]) : 100; $height = isset($height_matches[1]) ? absint($height_matches[1]) : 100;

---

Comment `/fix` on this issue to trigger the automated fix workflow.

---
*Auto-generated by opencode-ai-reviewer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened protection against scans targeting localhost and private or reserved network addresses.
  * Improved validation of plugin asset paths before loading them.
  * Enhanced sanitization of API keys and passwords in settings.

* **Bug Fixes**
  * Sanitized SVG dimensions with safe numeric defaults.
  * Improved image-processing error logs by using normalized file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->