### PR TITLE
⚡ Bolt: Cache minification checks

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -942,6 +942,15 @@ class Main {
 			return true;
 		}
 
+		$cache_key   = 'min_css_' . md5( $file_path );
+		$cache_group = 'wppo_minify_check';
+		$found       = false;
+		$cached      = wp_cache_get( $cache_key, $cache_group, false, $found );
+
+		if ( $found ) {
+			return (bool) $cached;
+		}
+
 		if ( ! file_exists( $file_path ) ) {
 			return true;
 		}
@@ -963,7 +972,10 @@ class Main {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		fclose( $handle );
 
-		return 10 >= $line_count;
+		$is_minified = 10 >= $line_count;
+		wp_cache_set( $cache_key, (int) $is_minified, $cache_group, HOUR_IN_SECONDS );
+
+		return $is_minified;
 	}
 
 	/**
@@ -983,6 +995,15 @@ class Main {
 			return true;
 		}
 
+		$cache_key   = 'min_js_' . md5( $file_path );
+		$cache_group = 'wppo_minify_check';
+		$found       = false;
+		$cached      = wp_cache_get( $cache_key, $cache_group, false, $found );
+
+		if ( $found ) {
+			return (bool) $cached;
+		}
+
 		if ( ! file_exists( $file_path ) ) {
 			return true;
 		}
@@ -1004,6 +1025,9 @@ class Main {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		fclose( $handle );
 
-		return 10 >= $line_count;
+		$is_minified = 10 >= $line_count;
+		wp_cache_set( $cache_key, (int) $is_minified, $cache_group, HOUR_IN_SECONDS );
+
+		return $is_minified;
 	}
 }


### PR DESCRIPTION
💡 What: Added WordPress Object Caching (`wp_cache_get` and `wp_cache_set`) to the `is_css_minified()` and `is_js_minified()` methods in `includes/class-main.php`. The minification status of an asset is now evaluated once per hour and cached using the MD5 hash of its file path as the key.
🎯 Why: Previously, when CSS/JS minification was enabled, these methods performed synchronous, blocking file I/O operations (`fopen` and `fgets` up to 10 lines) on every page load to check if an asset was already minified. This created a significant performance bottleneck, especially on pages loading many assets.
📊 Impact: Completely eliminates disk I/O for minification checks on cached assets, heavily reducing server load and reducing Time to First Byte (TTFB) during page generation.
🔬 Measurement: Verify by loading a frontend page with file optimization (minify CSS/JS) enabled. Measure the reduction in execution time and I/O operations (e.g., using Query Monitor or New Relic) compared to the unoptimized branch.

---
*PR created automatically by Jules for task [15592251322513053938](https://jules.google.com/task/15592251322513053938) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved CSS and JavaScript minification checks by caching results.
  * Reduced repeated file reads, helping minification detection complete more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->