### PR TITLE
[Autofix] Fix opencode ai feedback

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -926,23 +926,24 @@ class Main {
 	}
 
 	/**
-	 * Checks if a CSS file is already minified.
+	 * Checks if a file is already minified (shared helper for CSS/JS).
 	 *
-	 * @since 1.0.0
+	 * @since 1.5.1
 	 *
-	 * @param  string $file_path Path to the CSS file.
+	 * @param  string $file_path Path to the file.
+	 * @param  string $type      Asset type ('css' or 'js').
 	 * @return bool True if the file is minified, false otherwise.
 	 */
-	private function is_css_minified( $file_path ) {
+	private function is_file_minified( $file_path, $type ) {
 		if ( empty( $file_path ) ) {
 			return true;
 		}
 
-		if ( $this->is_minified_asset_name( $file_path, 'css' ) ) {
+		if ( $this->is_minified_asset_name( $file_path, $type ) ) {
 			return true;
 		}
 
-		$cache_key   = 'min_css_' . md5( $file_path );
+		$cache_key   = 'min_' . $type . '_' . md5( $file_path );
 		$cache_group = 'wppo_minify_check';
 		$found       = false;
 		$cached      = wp_cache_get( $cache_key, $cache_group, false, $found );
@@ -979,6 +980,18 @@ class Main {
 	}
 
 	/**
+	 * Checks if a CSS file is already minified.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param  string $file_path Path to the CSS file.
+	 * @return bool True if the file is minified, false otherwise.
+	 */
+	private function is_css_minified( $file_path ) {
+		return $this->is_file_minified( $file_path, 'css' );
+	}
+
+	/**
 	 * Checks if a JavaScript file is already minified.
 	 *
 	 * @since 1.0.0
@@ -987,47 +1000,6 @@ class Main {
 	 * @return bool True if the file is minified, false otherwise.
 	 */
 	private function is_js_minified( $file_path ) {
-		if ( empty( $file_path ) ) {
-			return true;
-		}
-
-		if ( $this->is_minified_asset_name( $file_path, 'js' ) ) {
-			return true;
-		}
-
-		$cache_key   = 'min_js_' . md5( $file_path );
-		$cache_group = 'wppo_minify_check';
-		$found       = false;
-		$cached      = wp_cache_get( $cache_key, $cache_group, false, $found );
-
-		if ( $found ) {
-			return (bool) $cached;
-		}
-
-		if ( ! file_exists( $file_path ) ) {
-			return true;
-		}
-
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-		$handle = fopen( $file_path, 'r' );
-		if ( ! $handle ) {
-			return true;
-		}
-
-		$line_count = 0;
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fgets
-		while ( false !== fgets( $handle ) ) {
-			++$line_count;
-			if ( $line_count > 10 ) {
-				break;
-			}
-		}
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-		fclose( $handle );
-
-		$is_minified = 10 >= $line_count;
-		wp_cache_set( $cache_key, (int) $is_minified, $cache_group, HOUR_IN_SECONDS );
-
-		return $is_minified;
+		return $this->is_file_minified( $file_path, 'js' );
 	}
 }

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'nilesh/performance-optimisation',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => '49c102fbb3c5bba136a87543f7a959725fb6c4b8',
+        'reference' => 'c69ed79d4bff7c7aae91bc314385c478db96f24b',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -40,7 +40,7 @@
         'nilesh/performance-optimisation' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => '49c102fbb3c5bba136a87543f7a959725fb6c4b8',
+            'reference' => 'c69ed79d4bff7c7aae91bc314385c478db96f24b',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Fixes #331

Verify each finding against current code. Fix only still-valid issues, skip the
rest with a brief reason, keep changes minimal, and validate.

Inline comments:
In `@includes/class-main.php`:
- Around line 945-953: Extract the duplicated asset minification evaluation and
caching lifecycle into a private is_file_minified($file_path, $type) helper,
preserving empty-path/name checks, cache miss handling via $found, file
evaluation, boolean casting, and cache writes. Replace is_css_minified and
is_js_minified with delegations to the helper using their respective asset
types. Apply this consolidation across includes/class-main.php ranges 945-953,
975-978, 998-1006, and 1028-1031; all four sites should be simplified or removed
as part of the shared-helper change.


---
*Auto-generated by opencode-ai-reviewer*