### PR TITLE
⚡ Bolt: Cache minification checks

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -942,6 +942,15 @@ class Main {
 			return true;
 		}
 
+		$cache_key   = 'min_css_' . md5( $file_path );
+		$cache_group = 'wppo_minify_check';
+		$found       = false;
+		$cached      = wp_cache_get( $cache_key, $cache_group, false, $found );
+
+		if ( $found ) {
+			return (bool) $cached;
+		}
+
 		if ( ! file_exists( $file_path ) ) {
 			return true;
 		}
@@ -963,7 +972,10 @@ class Main {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		fclose( $handle );
 
-		return 10 >= $line_count;
+		$is_minified = 10 >= $line_count;
+		wp_cache_set( $cache_key, (int) $is_minified, $cache_group, HOUR_IN_SECONDS );
+
+		return $is_minified;
 	}
 
 	/**
@@ -983,6 +995,15 @@ class Main {
 			return true;
 		}
 
+		$cache_key   = 'min_js_' . md5( $file_path );
+		$cache_group = 'wppo_minify_check';
+		$found       = false;
+		$cached      = wp_cache_get( $cache_key, $cache_group, false, $found );
+
+		if ( $found ) {
+			return (bool) $cached;
+		}
+
 		if ( ! file_exists( $file_path ) ) {
 			return true;
 		}
@@ -1004,6 +1025,9 @@ class Main {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		fclose( $handle );
 
-		return 10 >= $line_count;
+		$is_minified = 10 >= $line_count;
+		wp_cache_set( $cache_key, (int) $is_minified, $cache_group, HOUR_IN_SECONDS );
+
+		return $is_minified;
 	}
 }


### PR DESCRIPTION
Implemented WordPress Object Cache in `is_css_minified()` and `is_js_minified()` methods within `includes/class-main.php` to store the minification status of CSS and JS assets. This avoids expensive disk operations (`file_exists`, `fopen`, `fgets`) on every page load when file optimisation features are active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved asset processing performance by caching checks for whether CSS and JavaScript files are already minified.
  * Reduced repeated file reads during minification-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->