### PR TITLE
[Autofix] [Audit:performance] 0 critical, 6 important, 3 minor

### DIFF
--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -119,9 +119,20 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 
 			$this->url_path = $url_path;
 
-			// Initialize filesystem and options.
-			$this->filesystem = Util::init_filesystem();
-			$this->options    = get_option( 'wppo_settings', array() );
+			$this->options = get_option( 'wppo_settings', array() );
+		}
+
+		/**
+		 * Lazily initializes and returns the WP_Filesystem object.
+		 *
+		 * @return object|false The filesystem object or false on failure.
+		 * @since 1.6.0
+		 */
+		private function get_filesystem() {
+			if ( ! isset( $this->filesystem ) ) {
+				$this->filesystem = Util::init_filesystem();
+			}
+			return $this->filesystem;
 		}
 
 		/**
@@ -140,6 +151,47 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 
 			if ( empty( $styles ) ) {
 				return;
+			}
+
+			// Check if combined CSS file already exists and is fresh.
+			$css_file_path = $this->get_cache_file_path( 'css' );
+			if ( file_exists( $css_file_path ) ) {
+				$combined_mtime = filemtime( $css_file_path );
+				$all_fresh      = true;
+
+				foreach ( $styles as $handle ) {
+					if ( ! isset( $wp_styles->registered[ $handle ] ) ) {
+						$all_fresh = false;
+						break;
+					}
+
+					$src = $wp_styles->registered[ $handle ]->src;
+					if ( empty( $src ) ) {
+						$all_fresh = false;
+						break;
+					}
+
+					$local_path = Util::get_local_path( $src );
+					if ( ! $local_path || ! file_exists( $local_path ) ) {
+						$all_fresh = false;
+						break;
+					}
+
+					if ( filemtime( $local_path ) >= $combined_mtime ) {
+						$all_fresh = false;
+						break;
+					}
+				}
+
+				if ( $all_fresh ) {
+					$css_url = $this->get_cache_file_url( 'css' );
+					$version = $combined_mtime;
+					wp_enqueue_style( 'wppo-combine-css', $css_url, array(), $version, 'all' );
+
+					$css_url_with_version = $css_url . "?ver=$version";
+					echo '<link rel="preload" as="style" href="' . esc_url( $css_url_with_version ) . '">';
+					return;
+				}
 			}
 
 			$exclude_combine_css = array();
@@ -242,8 +294,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 			}
 
 			$css_file = Util::get_local_path( $url );
-			if ( $this->filesystem ) {
-				$css_content = $this->filesystem->get_contents( $css_file );
+			$fs       = $this->get_filesystem();
+			if ( $fs ) {
+				$css_content = $fs->get_contents( $css_file );
 
 				if ( false !== $css_content ) {
 					$css_content = CSS::update_image_paths( $css_content, $css_file );
@@ -270,7 +323,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 
 			$file_path = $this->get_cache_file_path();
 
-			if ( ! $this->filesystem || ! $this->prepare_cache_dir() ) {
+			if ( ! $this->get_filesystem() || ! $this->prepare_cache_dir() ) {
 				return;
 			}
 
@@ -480,10 +533,11 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 			$this->prepare_cache_dir();
 			$gzip_file_path = $file_path . '.gz';
 
-			$this->filesystem->put_contents( $file_path, $buffer, FS_CHMOD_FILE );
+			$fs = $this->get_filesystem();
+			$fs->put_contents( $file_path, $buffer, FS_CHMOD_FILE );
 
 			$gzip_output = gzencode( $buffer, 9 );
-			$this->filesystem->put_contents( $gzip_file_path, $gzip_output, FS_CHMOD_FILE );
+			$fs->put_contents( $gzip_file_path, $gzip_output, FS_CHMOD_FILE );
 		}
 
 		/**
@@ -631,9 +685,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 		private function delete_cache_files( $file_path ): bool {
 			$gzip_file_path = $file_path . '.gz';
 
-			if ( $this->filesystem ) {
-				$res1 = ! $this->filesystem->exists( $file_path ) || $this->filesystem->delete( $file_path );
-				$res2 = ! $this->filesystem->exists( $gzip_file_path ) || $this->filesystem->delete( $gzip_file_path );
+			$fs = $this->get_filesystem();
+			if ( $fs ) {
+				$res1 = ! $fs->exists( $file_path ) || $fs->delete( $file_path );
+				$res2 = ! $fs->exists( $gzip_file_path ) || $fs->delete( $gzip_file_path );
 				return $res1 && $res2;
 			}
 
@@ -692,14 +747,16 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 			$res1      = true;
 			$res2      = true;
 
-			if ( $this->filesystem && $this->filesystem->is_dir( $cache_dir ) ) {
-				$res1 = $this->filesystem->delete( $cache_dir, true ); // 'true' ensures recursive deletion.
+			$fs = $this->get_filesystem();
+
+			if ( $fs && $fs->is_dir( $cache_dir ) ) {
+				$res1 = $fs->delete( $cache_dir, true ); // 'true' ensures recursive deletion.
 			}
 
 			$min_dir = "{$this->cache_root_dir}/min";
 
-			if ( $this->filesystem && $this->filesystem->is_dir( $min_dir ) ) {
-				$res2 = $this->filesystem->delete( $min_dir, true ); // 'true' ensures recursive deletion.
+			if ( $fs && $fs->is_dir( $min_dir ) ) {
+				$res2 = $fs->delete( $min_dir, true ); // 'true' ensures recursive deletion.
 			}
 
 			return $res1 && $res2;
@@ -739,7 +796,8 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 		 */
 		private function calculate_directory_size( string $directory ): int {
 			$total_size = 0;
-			$files      = $this->filesystem->dirlist( $directory );
+			$fs         = $this->get_filesystem();
+			$files      = $fs->dirlist( $directory );
 
 			if ( ! $files ) {
 				return $total_size;
@@ -749,7 +807,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 				$file_path   = trailingslashit( $directory ) . $file['name'];
 				$total_size += ( 'd' === $file['type'] )
 					? $this->calculate_directory_size( $file_path )
-					: $this->filesystem->size( $file_path );
+					: $fs->size( $file_path );
 			}
 
 			return $total_size;

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -175,7 +175,7 @@ class Cron {
 		}
 
 		// Update iteration offset for the next batch.
-		update_option( 'wppo_preload_cron_offset', $paged_offset + 200 );
+		update_option( 'wppo_preload_cron_offset', $paged_offset + 200, false );
 
 		// Schedule next batch if needed.
 		if ( ! wp_next_scheduled( 'wppo_page_cron_batch' ) ) {
@@ -344,7 +344,7 @@ class Cron {
 
 		if ( $should_run ) {
 			Database_Cleanup::auto_clean( $settings );
-			update_option( 'wppo_last_db_cleanup', $now );
+			update_option( 'wppo_last_db_cleanup', $now, false );
 		}
 	}
 }

--- a/includes/class-database-cleanup.php
+++ b/includes/class-database-cleanup.php
@@ -118,25 +118,29 @@ class Database_Cleanup {
 
 		$revisions_to_delete = array();
 
-		foreach ( $parent_ids as $parent_id ) {
-			// Select exactly the cutoff entries so PHP handles almost no object data.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
-			$revisions = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT ID, post_date FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'revision' ORDER BY post_date DESC LIMIT 500",
-					$parent_id
-				)
-			);
+		$placeholders = implode( ',', array_fill( 0, count( $parent_ids ), '%d' ) );
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$all_revisions = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_parent, post_date FROM $wpdb->posts WHERE post_parent IN ( $placeholders ) AND post_type = 'revision' ORDER BY post_parent, post_date DESC",
+				$parent_ids
+			)
+		);
+		// phpcs:enable
 
-			if ( null === $revisions || ! empty( $wpdb->last_error ) ) {
-				continue;
-			}
+		if ( null === $all_revisions || ! empty( $wpdb->last_error ) ) {
+			return false;
+		}
 
-			// Keep the latest X revisions; dump others onto our purge list.
-			$older_revisions = array_slice( $revisions, $keep_latest );
+		$revisions_by_parent = array();
+		foreach ( $all_revisions as $rev ) {
+			$revisions_by_parent[ $rev->post_parent ][] = $rev;
+		}
 
-			foreach ( $older_revisions as $rev ) {
-				// Delete if older than cutoff.
+		foreach ( $revisions_by_parent as $parent_revisions ) {
+			$parent_revisions = array_slice( $parent_revisions, $keep_latest );
+
+			foreach ( $parent_revisions as $rev ) {
 				if ( $rev->post_date < $cutoff_date ) {
 					$revisions_to_delete[] = $rev->ID;
 				}
@@ -597,22 +601,22 @@ class Database_Cleanup {
 	 * @return array<string,int> Associative array mapping cleanup type to its current count.
 	 */
 	public static function get_counts() {
+		$cached = get_transient( 'wppo_db_cleanup_counts' );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
 		global $wpdb;
 
 		$time = time();
 
-		return array(
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Fetching latest database counts for cleanup; caching is not required for these live stats.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$counts = array(
 			'revisions'          => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = 'revision'" ),
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Fetching latest database counts for cleanup; caching is not required for these live stats.
 			'auto_drafts'        => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_status = 'auto-draft'" ),
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Fetching latest database counts for cleanup; caching is not required for these live stats.
 			'trashed_posts'      => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_status = 'trash'" ),
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Fetching latest database counts for cleanup; caching is not required for these live stats.
 			'spam_comments'      => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_approved = 'spam'" ),
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Fetching latest database counts for cleanup; caching is not required for these live stats.
 			'trashed_comments'   => (int) $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_approved = 'trash'" ),
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Fetching latest database counts for cleanup; caching is not required for these live stats.
 			'expired_transients' => (int) $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT COUNT(*) FROM $wpdb->options a
@@ -625,13 +629,16 @@ class Database_Cleanup {
 					$time
 				)
 			),
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Fetching latest database counts for cleanup; caching is not required for these live stats.
 			'orphan_postmeta'    => (int) $wpdb->get_var(
 				"SELECT COUNT(*) FROM $wpdb->postmeta pm
 				LEFT JOIN $wpdb->posts p ON p.ID = pm.post_id
 				WHERE p.ID IS NULL"
 			),
 		);
+		// phpcs:enable
+
+		set_transient( 'wppo_db_cleanup_counts', $counts, 5 * MINUTE_IN_SECONDS );
+		return $counts;
 	}
 
 	/**
@@ -647,6 +654,7 @@ class Database_Cleanup {
 		if ( false === $res ) {
 			return new WP_Error( 'db_cleanup_failed', sprintf( '%s failed', $method ) );
 		}
+		delete_transient( 'wppo_db_cleanup_counts' );
 		return $res;
 	}
 }

--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -266,6 +266,9 @@ class Img_Converter {
 						$imagick->clear();
 						return true;
 					} catch ( \Exception $e ) {
+						if ( isset( $imagick ) ) {
+							$imagick->clear();
+						}
 						$this->update_conversion_status( $source_image, 'failed', $format );
 						wp_delete_file( $webp_path );
 						return false;
@@ -346,22 +349,24 @@ class Img_Converter {
 	 * @since 1.0.0
 	 */
 	private function is_animated_webp( $file ) {
-		global $wp_filesystem;
-
-		if ( ! Util::init_filesystem() ) {
+		if ( ! file_exists( $file ) || ! is_readable( $file ) ) {
 			return false;
 		}
 
-		if ( ! $wp_filesystem->exists( $file ) || ! $wp_filesystem->is_readable( $file ) ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		$handle = fopen( $file, 'rb' );
+		if ( false === $handle ) {
 			return false;
 		}
 
-		$header = $wp_filesystem->get_contents( $file );
-		if ( false === $header ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread
+		$header = fread( $handle, 40 );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		fclose( $handle );
+
+		if ( false === $header || strlen( $header ) < 12 ) {
 			return false;
 		}
-
-		$header = substr( $header, 0, 40 );
 
 		if ( 'RIFF' !== substr( $header, 0, 4 ) || 'WEBP' !== substr( $header, 8, 4 ) ) {
 			return false;

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -479,6 +479,10 @@ class Main {
 	public function admin_enqueue_scripts(): void {
 		$screen = get_current_screen();
 
+		if ( 'toplevel_page_performance-optimisation' !== $screen->base ) {
+			return;
+		}
+
 		if ( is_admin_bar_showing() ) {
 			$asset_file = WPPO_PLUGIN_PATH . 'build/main.asset.php';
 			$resolved   = wp_normalize_path( realpath( $asset_file ) );
@@ -503,10 +507,6 @@ class Main {
 					'nonce_refresh' => wp_create_nonce( 'wppo_nonce_refresh' ),
 				)
 			);
-		}
-
-		if ( 'toplevel_page_performance-optimisation' !== $screen->base ) {
-			return;
 		}
 
 		$asset_file = WPPO_PLUGIN_PATH . 'build/index.asset.php';

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'nilesh/performance-optimisation',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => 'c69ed79d4bff7c7aae91bc314385c478db96f24b',
+        'reference' => '55a774a27a03ed438aa27735ab8d4e2c407cc6e5',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -40,7 +40,7 @@
         'nilesh/performance-optimisation' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => 'c69ed79d4bff7c7aae91bc314385c478db96f24b',
+            'reference' => '55a774a27a03ed438aa27735ab8d4e2c407cc6e5',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Fixes #334

<!-- audit-issue -->

## Audit: performance

**Target directory:** `includes`
**Results:** 0 critical, 6 important, 3 minor

**Summary:** Audited includes/ (25 files, ~11k lines). Found 9 issues (0 critical, 6 important, 3 minor).

### Findings

- **IMPORTANT** `includes/class-main.php:482` — Admin bar script wppo-admin-bar-script enqueued on every admin page (and frontend for logged-in users) via is_admin_bar_showing() check before the plugin-page gate at line 508. A performance optimisation plugin should not load JS on every admin screen.
  - *Fix:* Wrap the admin bar script enqueue block inside the same screen base check, or de-register it on non-plugin pages. Alternatively, inline the minimal JS needed for the admin bar buttons.
- **IMPORTANT** `includes/class-cache.php:133` — combine_css() always re-fetches all CSS files from the filesystem, minifies, and writes a new combined file on every uncached page load. It does not check whether the combined output file already exists and is fresh, causing redundant I/O and CPU work on every first visit.
  - *Fix:* Check if the combined CSS file at get_cache_file_path('css') exists and has an mtime newer than all contributing source files before re-processing. Short-circuit the full pipeline and just enqueue the existing combined file.
- **IMPORTANT** `includes/class-img-converter.php:359` — is_animated_webp() reads the entire WebP file into memory via $wp_filesystem->get_contents($file) but only inspects the first 40 bytes via substr($header,0,40). Animated WebP files can be many megabytes, making this a memory bomb during batch conversion jobs.
  - *Fix:* Read only the first 40 bytes (e.g., fopen() + fread(), or WP_Filesystem's get_contents() on a partial read) instead of loading the whole file.
- **IMPORTANT** `includes/class-cron.php:178` — wppo_preload_cron_offset is updated every preload batch (every ~60s) with autoload=true (default). Each update invalidates the alloptions cache, forcing WordPress to reload ALL autoloaded options on the next request — a significant perf hit during preloading.
  - *Fix:* Pass false as the 3rd argument to update_option() to disable autoload, or store the offset as a transient instead of an option.
- **IMPORTANT** `includes/class-database-cleanup.php:599` — get_counts() runs 7 separate COUNT(*) queries scanning full wp_posts, wp_comments, and wp_postmeta tables every time the Database Cleanup admin tab is loaded. No transient cache is used, so navigating to the tab always triggers these full-table scans.
  - *Fix:* Cache the counts result in a transient (e.g., wppo_db_cleanup_counts) with a 5-minute TTL and bust it after any cleanup operation completes.
- **IMPORTANT** `includes/class-cache.php:123` — Cache constructor calls Util::init_filesystem() on every page load, which triggers WP_Filesystem() — an admin-oriented API that performs credential checks and file includes. This adds measurable overhead to every frontend request where the Main class is loaded.
  - *Fix:* Defer filesystem initialisation until it is actually needed (e.g., in save_cache_files() or combine_css()). Pass the WP_Filesystem object or initialise lazily.
- **MINOR** `includes/class-database-cleanup.php:121` — clean_revisions_advanced() queries per-parent in a loop: up to 200 parent IDs × 1 query each = up to 200 queries. Although this runs only on manual cleanup (not page load), it is an N+1 pattern that could be consolidated into a single query.
  - *Fix:* Collect all parent IDs and use a single WHERE post_parent IN (...) query to fetch revisions for all parents, then group by parent_id in PHP.
- **MINOR** `includes/class-img-converter.php:268` — Imagick resource is not explicitly destroyed with clear()/destroy() in the exception handler for GIF-to-WebP conversion. While PHP GC will eventually free the memory, this can accumulate memory pressure during long-running batch conversion jobs.
  - *Fix:* Call $imagick->clear() or $imagick->destroy() in the catch block before returning.
- **MINOR** `includes/class-cron.php:347` — wppo_last_db_cleanup is updated with default autoload=true on each database cleanup run (daily/weekly/monthly). Causes minor alloptions cache invalidation.
  - *Fix:* Pass false as 3rd arg to update_option() or store as a transient.

---

Comment `/fix` on this issue to trigger the automated fix workflow.

---
*Auto-generated by opencode-ai-reviewer*