### PR TITLE
⚡ Bolt: Throttle expensive WP_CACHE environment checks on failure

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,7 @@
 ## 2025-01-22 - WPCS Error Suppression
 **Learning:** WordPress Coding Standards (WPCS) strongly discourages using the error suppression operator (`@`) before functions like `fopen()`. While it suppresses warnings when a file doesn't exist, it is better to rely on `file_exists()` before opening or catch exceptions.
 **Action:** Never use `@fopen()`. Rely on `file_exists()` and standard `$handle = fopen(...)` with a falsy check, and use `// phpcs:ignore` annotations to bypass strict file system rules.
+
+## 2026-07-21 - Throttle Environment Failure Checks
+**Learning:** When performing expensive environment checks (like file I/O to check or write to `wp-config.php`) inside high-frequency hooks like `admin_init`, failing to throttle the execution when the check *fails* will cause the application to repeatedly retry the failing operation on every single page load.
+**Action:** Always unconditionally set the throttle transient (using `set_transient`) outside of success/failure conditional blocks to prevent constant retry loops.

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -277,10 +277,10 @@ class Main {
 		require_once WPPO_PLUGIN_PATH . 'includes/class-activate.php';
 		$notices = Activate::add_wp_cache_constant();
 
-		if ( empty( $notices ) ) {
-			// Success — throttle for 1 hour.
-			set_transient( 'wppo_wp_cache_fix_checked', 1, HOUR_IN_SECONDS );
-		} else {
+		// Always throttle for 1 hour to avoid constant I/O on failure.
+		set_transient( 'wppo_wp_cache_fix_checked', 1, HOUR_IN_SECONDS );
+
+		if ( ! empty( $notices ) ) {
 			// Failure — merge notice keys into existing transient to notify user immediately.
 			$existing_notices = get_transient( 'wppo_activation_notices' );
 			$existing_notices = is_array( $existing_notices ) ? $existing_notices : array();


### PR DESCRIPTION
💡 What: Modified `Main::maybe_fix_wp_cache()` to unconditionally set the `wppo_wp_cache_fix_checked` throttle transient outside the success/failure conditional block.

🎯 Why: The previous implementation only set the 1-hour throttle if the attempt to add the `WP_CACHE` constant succeeded. If the server had strict file permissions (preventing writes to `wp-config.php`), `Activate::add_wp_cache_constant()` would repeatedly fail. Because the throttle transient was skipped on failure, the application repeatedly ran this expensive file I/O check on every single `admin_init` hook, creating a massive backend performance bottleneck.

📊 Impact: Eliminates a continuous File I/O retry loop on every `admin_init` for servers with strict permissions, significantly reducing WP-Admin page load latency.

🔬 Measurement: Profile the `admin_init` hook. Ensure that when `wp-config.php` is read-only and `WP_CACHE` is not defined, `Activate::add_wp_cache_constant()` is called exactly once, sets a notice, and is subsequently skipped for the next 1 hour due to the transient.

---
*PR created automatically by Jules for task [17601994323706868736](https://jules.google.com/task/17601994323706868736) started by @nilesh32236*