### PR TITLE
🔬 Inspector: Add tests for API error handling and retry logic

### DIFF
--- a/.jules/inspector.md
+++ b/.jules/inspector.md
@@ -30,3 +30,7 @@
 **Bug/Gap:** Some React UI components had uncovered lines handling edge cases such as rendering fallback components or API responses with 'success: false' rather than network errors.
 **Root Cause:** Component test coverage lacked thorough assertions for alternative code paths.
 **Test Added:** Implemented extensive frontend unit testing coverage using Jest + RTL to test these sad paths for SystemInfo and DatabaseCleanup components. Added mock assertions, timeout delays mocking using jest.useFakeTimers and explicit DOM interaction testing for React ConfirmDialog component.
+## 2026-07-21 - Missing edge case coverage in API library
+**Bug/Gap:** Missing branch coverage for `refreshNonce` error handling and initial API JSON parse failures.
+**Root Cause:** The `apiRequest.js` tests only checked successful network mocks and simple `fetch` rejections, missing the `rest_forbidden` retry logic flow.
+**Test Added:** Added explicit mocked `fetch` chained resolutions in Jest to simulate `rest_forbidden`, nonce refresh, and subsequent successful retries, as well as parsing failures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,16 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@fortawesome/free-solid-svg-icons": "^6.7.1",
-				"@fortawesome/react-fontawesome": "^0.2.2",
-				"@wordpress/element": "^6.43.0"
+				"@fortawesome/react-fontawesome": "^0.2.2"
 			},
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@wordpress/i18n": "^6.20.0",
 				"@wordpress/scripts": "^30.7.0"
+			},
+			"peerDependencies": {
+				"@wordpress/element": "^6.43.0"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -4701,7 +4703,8 @@
 			"version": "15.7.15",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
 			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/qs": {
 			"version": "6.9.17",
@@ -4718,6 +4721,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
 			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -4728,6 +4732,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -5864,6 +5869,7 @@
 			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
 			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
 			"license": "GPL-2.0-or-later",
+			"peer": true,
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
@@ -16514,6 +16520,7 @@
 		"node_modules/react": {
 			"version": "18.3.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -16524,6 +16531,7 @@
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -17197,6 +17205,7 @@
 		"node_modules/scheduler": {
 			"version": "0.23.2",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			}

--- a/src/lib/__tests__/apiRequest.test.js
+++ b/src/lib/__tests__/apiRequest.test.js
@@ -8,6 +8,7 @@ describe( 'API Request library', () => {
 			settings: {},
 		};
 		global.fetch = jest.fn();
+		jest.spyOn( console, 'error' ).mockImplementation( () => {} );
 	} );
 
 	afterEach( () => {
@@ -58,6 +59,168 @@ describe( 'API Request library', () => {
 			await expect( apiCall( 'some_action', {} ) ).rejects.toThrow(
 				'Network error'
 			);
+		} );
+
+		it( 'should throw custom error on initial JSON parse failure', async () => {
+			global.fetch.mockResolvedValueOnce( {
+				json: jest
+					.fn()
+					.mockRejectedValueOnce( new Error( 'Unexpected token <' ) ),
+			} );
+
+			await expect( apiCall( 'some_action', {} ) ).rejects.toThrow(
+				'Invalid JSON response from some_action: Unexpected token <'
+			);
+		} );
+
+		it( 'should refresh nonce and retry on rest_forbidden', async () => {
+			// 1. Initial request fails with rest_forbidden
+			const initialMockData = {
+				code: 'rest_forbidden',
+				message: 'Forbidden',
+			};
+			// 2. Refresh nonce request succeeds
+			const refreshMockData = { success: true, nonce: 'newnonce123' };
+			// 3. Retry request succeeds
+			const retryMockData = {
+				success: true,
+				data: { status: 'retried' },
+			};
+
+			global.fetch
+				.mockResolvedValueOnce( {
+					json: jest.fn().mockResolvedValueOnce( initialMockData ),
+				} )
+				.mockResolvedValueOnce( {
+					ok: true,
+					json: jest.fn().mockResolvedValueOnce( refreshMockData ),
+				} )
+				.mockResolvedValueOnce( {
+					json: jest.fn().mockResolvedValueOnce( retryMockData ),
+				} );
+
+			const result = await apiCall( 'some_action', {} );
+
+			// Check if nonce was updated in wppoSettings
+			expect( global.wppoSettings.nonce ).toBe( 'newnonce123' );
+			expect( result ).toEqual( retryMockData );
+			expect( global.fetch ).toHaveBeenCalledTimes( 3 );
+			// Check if refresh nonce was called
+			expect( global.fetch ).toHaveBeenNthCalledWith(
+				2,
+				'http://test.com/wp-json/wppo/v1/refresh_nonce'
+			);
+			// Check if retry was called with new nonce
+			expect( global.fetch ).toHaveBeenNthCalledWith(
+				3,
+				'http://test.com/wp-json/wppo/v1/some_action',
+				expect.objectContaining( {
+					headers: expect.objectContaining( {
+						'X-WP-Nonce': 'newnonce123',
+					} ),
+				} )
+			);
+		} );
+
+		it( 'should throw custom error on retry JSON parse failure', async () => {
+			// 1. Initial request fails with rest_forbidden
+			const initialMockData = {
+				code: 'rest_forbidden',
+				message: 'Forbidden',
+			};
+			// 2. Refresh nonce request succeeds
+			const refreshMockData = { success: true, nonce: 'newnonce123' };
+
+			global.fetch
+				.mockResolvedValueOnce( {
+					json: jest.fn().mockResolvedValueOnce( initialMockData ),
+				} )
+				.mockResolvedValueOnce( {
+					ok: true,
+					json: jest.fn().mockResolvedValueOnce( refreshMockData ),
+				} )
+				.mockResolvedValueOnce( {
+					json: jest
+						.fn()
+						.mockRejectedValueOnce(
+							new Error( 'Unexpected end of input' )
+						),
+				} );
+
+			await expect( apiCall( 'some_action', {} ) ).rejects.toThrow(
+				'Invalid JSON response from some_action (retry): Unexpected end of input'
+			);
+		} );
+
+		it( 'should fall back to old nonce if refreshNonce fetch fails', async () => {
+			// 1. Initial request fails with rest_forbidden
+			const initialMockData = {
+				code: 'rest_forbidden',
+				message: 'Forbidden',
+			};
+			// 3. Retry request succeeds (using old nonce because refresh failed)
+			const retryMockData = {
+				success: true,
+				data: { status: 'retried_with_old_nonce' },
+			};
+
+			global.fetch
+				.mockResolvedValueOnce( {
+					json: jest.fn().mockResolvedValueOnce( initialMockData ),
+				} )
+				.mockResolvedValueOnce( {
+					ok: false, // Simulate !res.ok
+				} )
+				.mockResolvedValueOnce( {
+					json: jest.fn().mockResolvedValueOnce( retryMockData ),
+				} );
+
+			const result = await apiCall( 'some_action', {} );
+
+			expect( global.wppoSettings.nonce ).toBe( 'testnonce' );
+			expect( result ).toEqual( retryMockData );
+			// Check if retry was called with OLD nonce
+			expect( global.fetch ).toHaveBeenNthCalledWith(
+				3,
+				'http://test.com/wp-json/wppo/v1/some_action',
+				expect.objectContaining( {
+					headers: expect.objectContaining( {
+						'X-WP-Nonce': 'testnonce',
+					} ),
+				} )
+			);
+		} );
+
+		it( 'should log error if refreshNonce throws error', async () => {
+			// 1. Initial request fails with rest_forbidden
+			const initialMockData = {
+				code: 'rest_forbidden',
+				message: 'Forbidden',
+			};
+			// 3. Retry request succeeds (using old nonce because refresh failed)
+			const retryMockData = {
+				success: true,
+				data: { status: 'retried_with_old_nonce' },
+			};
+			const refreshError = new Error( 'Refresh error' );
+
+			global.fetch
+				.mockResolvedValueOnce( {
+					json: jest.fn().mockResolvedValueOnce( initialMockData ),
+				} )
+				.mockRejectedValueOnce( refreshError ) // Simulate fetch rejection
+				.mockResolvedValueOnce( {
+					json: jest.fn().mockResolvedValueOnce( retryMockData ),
+				} );
+
+			const result = await apiCall( 'some_action', {} );
+
+			expect( console.error ).toHaveBeenCalledWith(
+				'Nonce refresh failed:',
+				refreshError
+			);
+			expect( global.wppoSettings.nonce ).toBe( 'testnonce' );
+			expect( result ).toEqual( retryMockData );
 		} );
 	} );
 
@@ -323,20 +486,13 @@ describe( 'API Request library', () => {
 			const mockError = new Error( 'Failed to fetch' );
 			global.fetch.mockRejectedValueOnce( mockError );
 
-			// Mock console.error
-			const consoleSpy = jest
-				.spyOn( console, 'error' )
-				.mockImplementation( () => {} );
-
 			await expect( fetchRecentActivities() ).rejects.toThrow(
 				'Failed to fetch'
 			);
-			expect( consoleSpy ).toHaveBeenCalledWith(
+			expect( console.error ).toHaveBeenCalledWith(
 				'Error fetching recent activities: ',
 				mockError
 			);
-
-			consoleSpy.mockRestore();
 		} );
 	} );
 } );


### PR DESCRIPTION
💡 Gap: The `apiCall` wrapper in `apiRequest.js` was missing branch coverage for its most critical edge cases, specifically the nonce refresh and retry logic when receiving a `rest_forbidden` code, as well as handling JSON parsing errors.

🎯 Coverage: Added comprehensive unit tests in `apiRequest.test.js` covering:
- Custom error thrown on initial JSON parse failure.
- Successful nonce refresh and retry on `rest_forbidden`.
- Custom error thrown on retry JSON parse failure.
- Fallback to the old nonce if the `refreshNonce` fetch fails.
- Error logging when `refreshNonce` throws an internal error.

📊 Tools Used: Ran Jest coverage reports (`npm run test -- --coverage`) to isolate the uncovered lines (`12-24`, `58`, `71-81`) and chained `global.fetch.mockResolvedValueOnce` to simulate the multi-step `rest_forbidden` flow.

---
*PR created automatically by Jules for task [14841022080638895405](https://jules.google.com/task/14841022080638895405) started by @nilesh32236*