### PR TITLE
🚜 Warden: [Code Quality Improvement] - Refactor img_convert_cron for DRYness and efficiency

### DIFF
--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -310,43 +310,35 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 
 				$normalized_abspath = trailingslashit( wp_normalize_path( ABSPATH ) );
 
-				if ( in_array( $conversion_format, array( 'avif', 'both' ), true ) ) {
-					$images = $img_info['pending']['avif'] ?? array();
-
-					$counter = 0;
-					if ( ! empty( $images ) ) {
-						foreach ( $images as $img ) {
-							++$counter;
-
-							if ( $counter <= $batch_size ) {
-								$source_path = wp_normalize_path( ABSPATH . $img );
-								$resolved    = realpath( $source_path );
-								if ( false === $resolved || 0 !== strpos( wp_normalize_path( $resolved ), $normalized_abspath ) ) {
-									continue;
-								}
-								$img_converter->convert_image( $source_path, 'avif' );
-							}
-						}
-					}
+				$formats_to_process = array();
+				if ( 'both' === $conversion_format ) {
+					$formats_to_process = array( 'avif', 'webp' );
+				} elseif ( in_array( $conversion_format, array( 'avif', 'webp' ), true ) ) {
+					$formats_to_process[] = $conversion_format;
 				}
 
-				if ( in_array( $conversion_format, array( 'webp', 'both' ), true ) ) {
-					$images = $img_info['pending']['webp'] ?? array();
+				foreach ( $formats_to_process as $format ) {
+					$images = $img_info['pending'][ $format ] ?? array();
+
+					if ( empty( $images ) ) {
+						continue;
+					}
 
 					$counter = 0;
-					if ( ! empty( $images ) ) {
-						foreach ( $images as $img ) {
-							++$counter;
-
-							if ( $counter <= $batch_size ) {
-								$source_path = wp_normalize_path( ABSPATH . $img );
-								$resolved    = realpath( $source_path );
-								if ( false === $resolved || 0 !== strpos( wp_normalize_path( $resolved ), $normalized_abspath ) ) {
-									continue;
-								}
-								$img_converter->convert_image( $source_path );
-							}
+					foreach ( $images as $img ) {
+						if ( $counter >= $batch_size ) {
+							break;
 						}
+
+						++$counter;
+
+						$source_path = wp_normalize_path( ABSPATH . $img );
+						$resolved    = realpath( $source_path );
+						if ( false === $resolved || 0 !== strpos( wp_normalize_path( $resolved ), $normalized_abspath ) ) {
+							continue;
+						}
+
+						$img_converter->convert_image( $source_path, $format );
 					}
 				}
 			} finally {


### PR DESCRIPTION
## What was cleaned up
The `img_convert_cron` function in `includes/class-cron.php` contained two nearly identical loops for processing `avif` and `webp` images. Inside these loops, a redundant iteration issue existed where it iterated through all remaining images in the array even after the batch limit had been reached, simply performing a no-op check `if ( $counter <= $batch_size )` instead of breaking out. 

## Why it was messy
- The duplicated blocks violated the DRY (Don't Repeat Yourself) principle, making future modifications to the image queuing logic require identical changes in two separate places.
- The use of `if ( $counter <= $batch_size )` instead of a `break` statement resulted in wasted CPU cycles iterating over potentially thousands of remaining image paths after the batch limit was already hit.
- A nested `! empty( $images )` check wrapped the entire loop, increasing indentation and cognitive load.

## How the new structure improves readability
- A new `$formats_to_process` array is built based on the `$conversion_format` settings. A single `foreach` loop now iterates over this array, executing the image processing block cleanly and efficiently for each required format.
- Added a guard clause (`if ( empty( $images ) ) { continue; }`) to remove an unnecessary level of nesting.
- Added a short-circuit guard clause inside the loop (`if ( $counter >= $batch_size ) { break; }`) to immediately halt iteration when the batch limit is reached, optimizing performance for large queues.

---
*PR created automatically by Jules for task [12098686376570457837](https://jules.google.com/task/12098686376570457837) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled image conversion processing for AVIF and WebP formats.
  * Enforced configured batch limits consistently across conversion formats.
  * Added safeguards to prevent processing image paths outside the WordPress installation directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->