### PR TITLE
[Autofix] [Audit:code-quality] 1 critical, 9 important, 6 minor

### DIFF
--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -681,7 +681,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 			}
 
 			if ( ! wp_next_scheduled( 'wppo_generate_static_page', array( $page_id ) ) ) {
-				wp_schedule_single_event( time() + \wp_rand( 0, 5 ), 'wppo_generate_static_page', array( $page_id ) );
+				wp_schedule_single_event( time() + wp_rand( 0, 5 ), 'wppo_generate_static_page', array( $page_id ) );
 			}
 		}
 

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -179,7 +179,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 					}
 
 					if ( ! wp_next_scheduled( 'wppo_generate_static_page', array( $page_id ) ) ) {
-						wp_schedule_single_event( time() + \wp_rand( 0, 1800 ), 'wppo_generate_static_page', array( $page_id ) );
+						wp_schedule_single_event( time() + wp_rand( 0, 1800 ), 'wppo_generate_static_page', array( $page_id ) );
 					}
 				}
 
@@ -241,11 +241,15 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 			$response = wp_remote_get( $permalink, array( 'timeout' => 30 ) );
 			if ( is_wp_error( $response ) ) {
 				$clean_err = sanitize_text_field( str_replace( ABSPATH, '', $response->get_error_message() ) );
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( 'WPPO preload failed for page ' . (int) $page_id . ': ' . $clean_err );
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( 'WPPO preload failed for page ' . (int) $page_id . ': ' . $clean_err );
+				}
 			} elseif ( wp_remote_retrieve_response_code( $response ) >= 400 ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( 'WPPO preload failed: HTTP status ' . (int) wp_remote_retrieve_response_code( $response ) );
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( 'WPPO preload failed: HTTP status ' . (int) wp_remote_retrieve_response_code( $response ) );
+				}
 			}
 		}
 

--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -133,8 +133,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 			// Security Fix: Prevent File Size & Memory Bomb DoS.
 			$max_bytes = apply_filters( 'wppo_filesize_limit_bytes', 20 * 1024 * 1024 );
 			if ( filesize( $source_image ) > $max_bytes ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( 'WPPO Error: Image exceeds maximum filesize limit' );
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( 'WPPO Error: Image exceeds maximum filesize limit' );
+				}
 				$this->update_conversion_status( $source_image, 'failed', $format );
 				return false;
 			}
@@ -157,8 +159,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 				)
 			);
 			if ( $image_info[0] > $max_dims['width'] || $image_info[1] > $max_dims['height'] ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( 'WPPO Error: Image dimensions exceed maximum allowed' );
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( 'WPPO Error: Image dimensions exceed maximum allowed' );
+				}
 				$this->update_conversion_status( $source_image, 'failed', $format );
 				return false;
 			}
@@ -353,7 +357,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 					error_log( 'WPPO Image conversion failed: ' . str_replace( ABSPATH, '', $e->getMessage() ) );
 				}
-				new Log( __( 'Image conversion failed.', 'performance-optimisation' ) );
+				Log::add( __( 'Image conversion failed.', 'performance-optimisation' ) );
 
 				return false;
 			}
@@ -579,8 +583,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 				return $metadata;
 
 			} catch ( \Exception $e ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( 'WPPO Image conversion error for attachment ID ' . (int) $attachment_id . ': ' . str_replace( ABSPATH, '', $e->getMessage() ) );
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( 'WPPO Image conversion error for attachment ID ' . (int) $attachment_id . ': ' . str_replace( ABSPATH, '', $e->getMessage() ) );
+				}
 				return $metadata;
 			}
 		}
@@ -701,8 +707,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 
 			// Only queue images that live inside wp-content/uploads.
 			if ( strpos( $normalized, $upload_dir ) !== 0 ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( 'WPPO: add_img_into_queue rejected path — not inside uploads directory.' );
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( 'WPPO: add_img_into_queue rejected path — not inside uploads directory.' );
+				}
 				return false;
 			}
 

--- a/includes/class-object-cache.php
+++ b/includes/class-object-cache.php
@@ -224,8 +224,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Object_Cache' ) ) {
 					if ( method_exists( $connection, 'close' ) ) {
 						$connection->close();
 					}
-					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-					error_log( 'Redis ping exception: ' . $e->getMessage() );
+					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+						// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+						error_log( 'Redis ping exception: ' . $e->getMessage() );
+					}
 					return new \WP_Error( 'ping_exception', __( 'Redis connection failed.', 'performance-optimisation' ) );
 				}
 			}

--- a/includes/redis-connect-helper.php
+++ b/includes/redis-connect-helper.php
@@ -78,8 +78,10 @@ if ( ! function_exists( 'wppo_redis_connect' ) ) {
 
 			return wppo_redis_connect_standalone( $config );
 		} catch ( \Throwable $e ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'WPPO Redis connection failed' );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'WPPO Redis connection failed' );
+			}
 			return new \WP_Error( 'redis_err', __( 'Redis connection failed.', 'performance-optimisation' ) );
 		}
 	}
@@ -90,7 +92,7 @@ if ( ! function_exists( 'wppo_redis_connect_cluster' ) ) {
 	 * Establishes a Redis Cluster connection.
 	 *
 	 * @param array $config Redis configuration.
-	 * @since NEXT
+	 * @since 2.1.0
 	 * @return \RedisCluster|\WP_Error A connected RedisCluster client or a WP_Error on failure.
 	 */
 	function wppo_redis_connect_cluster( $config ) {
@@ -124,8 +126,10 @@ if ( ! function_exists( 'wppo_redis_connect_cluster' ) ) {
 
 			return $cluster;
 		} catch ( \Throwable $e ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( 'WPPO Redis cluster connection failed' );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'WPPO Redis cluster connection failed' );
+			}
 			return new \WP_Error( 'cluster_fail', __( 'Redis Cluster connection failed.', 'performance-optimisation' ) );
 		}
 	}
@@ -136,7 +140,7 @@ if ( ! function_exists( 'wppo_redis_connect_sentinel' ) ) {
 	 * Establishes a Redis Sentinel connection.
 	 *
 	 * @param array $config Redis configuration.
-	 * @since NEXT
+	 * @since 2.1.0
 	 * @return \Redis|\WP_Error A connected Redis client or a WP_Error on failure.
 	 */
 	function wppo_redis_connect_sentinel( $config ) {
@@ -227,7 +231,7 @@ if ( ! function_exists( 'wppo_redis_connect_standalone' ) ) {
 	 * Establishes a standalone Redis connection.
 	 *
 	 * @param array $config Redis configuration.
-	 * @since NEXT
+	 * @since 2.1.0
 	 * @return \Redis|\WP_Error A connected Redis client or a WP_Error on failure.
 	 */
 	function wppo_redis_connect_standalone( $config ) {
@@ -278,7 +282,7 @@ if ( ! function_exists( 'wppo_parse_redis_node' ) ) {
 	 * Handles standard "host:port" formats as well as IPv6 enclosed in brackets.
 	 *
 	 * @param string $node The node string to parse.
-	 * @since NEXT
+	 * @since 2.1.0
 	 * @return array Associative array containing 'host' and 'port'.
 	 */
 	function wppo_parse_redis_node( $node ) {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'nilesh/performance-optimisation',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => '273ca8b03085cd544f0f50e3472642c8856580c0',
+        'reference' => '78ee6301e4a06a0d71b01c3943dd60e0350037c9',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -40,7 +40,7 @@
         'nilesh/performance-optimisation' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => '273ca8b03085cd544f0f50e3472642c8856580c0',
+            'reference' => '78ee6301e4a06a0d71b01c3943dd60e0350037c9',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Fixes #345

<!-- audit-issue -->

## Audit: code-quality

**Target directory:** `includes`
**Results:** 1 critical, 9 important, 6 minor

**Summary:** 

### Findings

- **CRITICAL** `includes/class-img-converter.php:356` — Fatal error: `new Log(...)` attempts to instantiate Log class via private constructor. Log::__construct() is private (class-log.php:34). Must use static `Log::add(...)` instead.
  - *Fix:* Replace `new Log(...)` with `Log::add(...)` on line 356.
- **IMPORTANT** `includes/class-object-cache.php:228` — `error_log()` called without WP_DEBUG guard. Production sites may leak debug info into error logs.
  - *Fix:* Wrap in `if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) { ... }` or use a dedicated logger.
- **IMPORTANT** `includes/class-cron.php:245` — `error_log()` called without WP_DEBUG guard. Preload failure details may leak to production error logs.
  - *Fix:* Gate behind `WP_DEBUG` check.
- **IMPORTANT** `includes/class-cron.php:248` — `error_log()` called without WP_DEBUG guard. HTTP status details may leak to production error logs.
  - *Fix:* Gate behind `WP_DEBUG` check.
- **IMPORTANT** `includes/class-img-converter.php:137` — `error_log()` called without WP_DEBUG guard. Image filesize error leaks to production logs.
  - *Fix:* Wrap in `if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) { ... }`.
- **IMPORTANT** `includes/class-img-converter.php:161` — `error_log()` called without WP_DEBUG guard. Image dimension error leaks to production logs.
  - *Fix:* Wrap in `if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) { ... }`.
- **IMPORTANT** `includes/class-img-converter.php:583` — `error_log()` called without WP_DEBUG guard. Conversion failure details leak to production logs.
  - *Fix:* Wrap in `if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) { ... }`.
- **IMPORTANT** `includes/class-img-converter.php:705` — `error_log()` called without WP_DEBUG guard. Queue rejection details leak to production logs.
  - *Fix:* Wrap in `if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) { ... }`.
- **IMPORTANT** `includes/redis-connect-helper.php:82` — `error_log()` called without WP_DEBUG guard. Redis connection failure leaks to production logs.
  - *Fix:* Wrap in `if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) { ... }`.
- **IMPORTANT** `includes/redis-connect-helper.php:128` — `error_log()` called without WP_DEBUG guard. Redis cluster connection failure leaks to production logs.
  - *Fix:* Wrap in `if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) { ... }`.
- **MINOR** `includes/redis-connect-helper.php:93` — `@since NEXT` placeholder found — must be replaced with actual version number before release.
  - *Fix:* Replace `NEXT` with the target release version (e.g., `@since 2.1.0`).
- **MINOR** `includes/redis-connect-helper.php:139` — `@since NEXT` placeholder found.
  - *Fix:* Replace `NEXT` with target release version.
- **MINOR** `includes/redis-connect-helper.php:230` — `@since NEXT` placeholder found.
  - *Fix:* Replace `NEXT` with target release version.
- **MINOR** `includes/redis-connect-helper.php:281` — `@since NEXT` placeholder found.
  - *Fix:* Replace `NEXT` with target release version.
- **MINOR** `includes/class-cron.php:182` — Unnecessary global namespace prefix `\wp_rand()`. The fully-qualified name is redundant since no local `wp_rand()` function exists in this namespace.
  - *Fix:* Call `wp_rand()` without leading backslash.
- **MINOR** `includes/class-cache.php:684` — Unnecessary global namespace prefix `\wp_rand()`. Same pattern as class-cron.php:182.
  - *Fix:* Call `wp_rand()` without leading backslash.

---

Comment `/fix` on this issue to trigger the automated fix workflow.

---
*Auto-generated by opencode-ai-reviewer*