### PR TITLE
⚡ Bolt: [performance improvement] Reduce redundant regex generation and lazy-evaluate path lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,7 @@
 ## 2026-07-21 - Throttle Environment Failure Checks
 **Learning:** When performing expensive environment checks (like file I/O to check or write to `wp-config.php`) inside high-frequency hooks like `admin_init`, failing to throttle the execution when the check *fails* will cause the application to repeatedly retry the failing operation on every single page load.
 **Action:** Always unconditionally set the throttle transient (using `set_transient`) outside of success/failure conditional blocks to prevent constant retry loops.
+
+## 2025-01-22 - Redundant Operations in Parsers
+**Learning:** Functions called within high-frequency loops, such as parsing HTML tags, can cause significant performance degradation. Generating regular expressions via `preg_quote` and doing complex URL processing (like `Util::get_local_path`) for each tag or property evaluated can add substantial overhead across a large document.
+**Action:** Lift static computations and string transformations out of loops when parsing. Delay expensive lookups (like resolving local filesystem paths) with lazy evaluation, ensuring they're executed at most once per distinct resource.

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -416,7 +416,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 				return $buffer;
 			}
 
-			$tags = new \WP_HTML_Tag_Processor( $buffer );
+			// Cache the expensive regex generation outside the loop to improve performance.
+			$site_url_regex = '#^' . preg_quote( $site_url, '#' ) . '(/|$)#';
+			$tags           = new \WP_HTML_Tag_Processor( $buffer );
 
 			while ( $tags->next_tag() ) {
 				$tag_name = strtolower( $tags->get_tag() );
@@ -429,7 +431,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 				foreach ( $attributes as $attr ) {
 					$val = $tags->get_attribute( $attr );
 
-					if ( $val && preg_match( '#^' . preg_quote( $site_url, '#' ) . '(/|$)#', $val ) && preg_match( '#\/(?:wp-content|wp-includes)\/#', $val ) ) {
+					if ( $val && preg_match( $site_url_regex, $val ) && preg_match( '#\/(?:wp-content|wp-includes)\/#', $val ) ) {
 						$tags->set_attribute( $attr, str_replace( $site_url, $cdn_url, $val ) );
 					}
 				}
@@ -446,7 +448,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 							$url       = $parts[0];
 							$suffix    = isset( $parts[1] ) ? ' ' . $parts[1] : '';
 
-							if ( preg_match( '#^' . preg_quote( $site_url, '#' ) . '(/|$)#', $url ) && preg_match( '#\/(?:wp-content|wp-includes)\/#', $url ) ) {
+							if ( preg_match( $site_url_regex, $url ) && preg_match( '#\/(?:wp-content|wp-includes)\/#', $url ) ) {
 								$url = str_replace( $site_url, $cdn_url, $url );
 							}
 							$new_srcset[] = $url . $suffix;

--- a/includes/class-image-optimisation.php
+++ b/includes/class-image-optimisation.php
@@ -324,6 +324,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 			$avif_img_path = $img_converter->get_img_path( $img_url, 'avif' );
 			$webp_img_path = $img_converter->get_img_path( $img_url, 'webp' );
 
+			// Cache local path lookups to avoid redundant expensive file system checks.
+			$source_image_path = null;
+
 			if ( 'avif' === $conversion_format || 'both' === $conversion_format ) {
 				// Convert to AVIF if supported and not already converted.
 				if ( ! file_exists( $avif_img_path ) ) {
@@ -338,7 +341,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 			if ( 'webp' === $conversion_format || 'both' === $conversion_format ) {
 				// Convert to WebP if supported and not already converted.
 				if ( ! file_exists( $webp_img_path ) ) {
-					$source_image_path = Util::get_local_path( $img_url );
+					if ( null === $source_image_path ) {
+						$source_image_path = Util::get_local_path( $img_url );
+					}
 
 					if ( file_exists( $source_image_path ) ) {
 						$img_converter->add_img_into_queue( $source_image_path );


### PR DESCRIPTION
💡 What: 
- Extracted a static `preg_quote()` generation for `$site_url` out of a `WP_HTML_Tag_Processor` loop in `includes/class-cache.php`.
- Lazily evaluated `Util::get_local_path()` inside `includes/class-image-optimisation.php` when converting an image to both AVIF and WebP, preventing it from being unnecessarily called twice.

🎯 Why:
- Redundant regular expression compilation inside high-frequency loops (like HTML tag processing) adds unnecessary computational overhead.
- Parsing URLs and resolving local file paths via `Util::get_local_path()` is an expensive string operation. Calling it twice for the exact same source image URL when generating AVIF and WebP variants is wasteful.

📊 Impact:
- Reduces string operations and regex compilations per page load significantly. For a page with dozens of images and `srcset` variants, `preg_quote()` was previously executed hundreds of times redundantly.
- Saves at least one redundant `Util::get_local_path()` call per image processing attempt when dual format conversions are enabled.

🔬 Measurement:
- Inspect `includes/class-cache.php` and verify `$site_url_regex` is computed once.
- Check `includes/class-image-optimisation.php` and confirm `$source_image_path` is instantiated only when required and reused for both conversion format tests.

---
*PR created automatically by Jules for task [6273755455358734687](https://jules.google.com/task/6273755455358734687) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved efficiency when rewriting CDN URLs.
  * Reduced repeated image path resolution during next-generation image processing.
  * Added guidance to avoid redundant operations in high-frequency parsing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->