### PR TITLE
🚔 Warden: [Code Quality Improvement]

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -665,10 +665,16 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 		 * @since 1.0.0
 		 */
 		public function remove_woocommerce_scripts() {
-			$exclude_url_to_keep_js_css = array();
-			if ( isset( $this->options['file_optimisation']['excludeUrlToKeepJSCSS'] ) && ! empty( $this->options['file_optimisation']['excludeUrlToKeepJSCSS'] ) ) {
-				$exclude_url_to_keep_js_css = Util::process_urls( $this->options['file_optimisation']['excludeUrlToKeepJSCSS'] );
+			if ( empty( $this->options['file_optimisation']['removeCssJsHandle'] ) ) {
+				return;
+			}
 
+			$exclude_url_to_keep_js_css = array();
+			if ( ! empty( $this->options['file_optimisation']['excludeUrlToKeepJSCSS'] ) ) {
+				$exclude_url_to_keep_js_css = Util::process_urls( $this->options['file_optimisation']['excludeUrlToKeepJSCSS'] );
+			}
+
+			if ( ! empty( $exclude_url_to_keep_js_css ) ) {
 				// Safely retrieve and sanitize the current URL.
 				$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 				$parsed_uri  = str_replace( wp_parse_url( home_url(), PHP_URL_PATH ) ?? '', '', $request_uri );
@@ -693,24 +699,19 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				}
 			}
 
-			$remove_css_js_handle = array();
-			if ( isset( $this->options['file_optimisation']['removeCssJsHandle'] ) && ! empty( $this->options['file_optimisation']['removeCssJsHandle'] ) ) {
-				$remove_css_js_handle = Util::process_urls( $this->options['file_optimisation']['removeCssJsHandle'] );
-			}
+			$remove_css_js_handle = Util::process_urls( $this->options['file_optimisation']['removeCssJsHandle'] );
 
-			if ( ! empty( $remove_css_js_handle ) ) {
-				foreach ( $remove_css_js_handle as $handle ) {
-					if ( 0 === strpos( $handle, 'style:' ) ) {
-						$handle = str_replace( 'style:', '', $handle );
-						$handle = trim( $handle );
+			foreach ( $remove_css_js_handle as $handle ) {
+				if ( 0 === strpos( $handle, 'style:' ) ) {
+					$handle = str_replace( 'style:', '', $handle );
+					$handle = trim( $handle );
 
-						wp_dequeue_style( $handle );
-					} elseif ( 0 === strpos( $handle, 'script:' ) ) {
-						$handle = str_replace( 'script:', '', $handle );
-						$handle = trim( $handle );
+					wp_dequeue_style( $handle );
+				} elseif ( 0 === strpos( $handle, 'script:' ) ) {
+					$handle = str_replace( 'script:', '', $handle );
+					$handle = trim( $handle );
 
-						wp_dequeue_script( $handle );
-					}
+					wp_dequeue_script( $handle );
 				}
 			}
 		}


### PR DESCRIPTION
### What was cleaned up
Extracted the early logic checking for `removeCssJsHandle` into an early return guard clause and removed the redundant `! empty()` condition wrapping the `foreach` loops for `$remove_css_js_handle`.

### Why it was messy
The `remove_woocommerce_scripts` method was nested too deeply for conditions that could be resolved early (especially if the array to check is empty). Also, `! empty( $remove_css_js_handle )` wrapped around `foreach ( $remove_css_js_handle as $handle )` is redundant because PHP's `foreach` gracefully skips empty arrays natively, leading to unnecessary block nesting and visual clutter.

### How the new structure improves readability
Adding an early return at the top makes the baseline flow clearer, indicating exactly what conditions stop the rest of the script from processing. The removal of the `! empty( ... )` block flattens the execution path of the `foreach` loop, adhering closer to standard PHP and WPCS structural cleanliness by reducing cognitive complexity and horizontal indentation.

---
*PR created automatically by Jules for task [2595159310157211219](https://jules.google.com/task/2595159310157211219) started by @nilesh32236*