### PR TITLE
[Autofix] [Audit:performance] 0 critical, 4 important, 7 minor

### DIFF
--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -103,11 +103,20 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 		private $options;
 
 		/**
+		 * Image_Optimisation instance for buffer processing.
+		 *
+		 * @var Image_Optimisation|null
+		 * @since 2.0.0
+		 */
+		private $image_optimisation;
+
+		/**
 		 * Constructor to initialize cache settings and configurations.
 		 *
+		 * @param array $options Plugin options (optional). When empty, loaded from DB.
 		 * @since 1.0.0
 		 */
-		public function __construct() {
+		public function __construct( array $options = array() ) {
 			$domain = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
 
 			// Convert internationalized domain names to ASCII (punycode) to support IDN chars.
@@ -151,11 +160,22 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 			$this->url_path = $url_path;
 
 			// Initialize filesystem lazily via get_filesystem().
-			$this->options = get_option( 'wppo_settings', array() );
+			$this->options = ! empty( $options ) ? $options : get_option( 'wppo_settings', array() );
 
 			if ( ! $valid_domain && ! empty( $this->options['debug'] ) ) {
 				do_action( 'wppo_debug_log', 'Cache domain validation failed' );
 			}
+		}
+
+		/**
+		 * Set the Image_Optimisation instance to reuse instead of creating a new one.
+		 *
+		 * @param Image_Optimisation $image_optimisation The existing instance.
+		 * @return void
+		 * @since 2.0.0
+		 */
+		public function set_image_optimisation( Image_Optimisation $image_optimisation ): void {
+			$this->image_optimisation = $image_optimisation;
 		}
 
 		/**
@@ -365,7 +385,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 		 * @since 1.0.0
 		 */
 		private function process_buffer( $buffer, $file_path ) {
-			$image_optimisation = new Image_Optimisation( $this->options );
+			$image_optimisation = $this->image_optimisation ? $this->image_optimisation : new Image_Optimisation( $this->options );
 
 			$buffer = $image_optimisation->maybe_serve_next_gen_images( $buffer );
 			$buffer = $image_optimisation->add_delay_load_img( $buffer );
@@ -663,19 +683,25 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 					$this->delete_cache_files( $this->get_file_path( $archive_path, 'html' ) );
 				}
 
-				$taxonomies = get_object_taxonomies( $post_type, 'objects' );
-				foreach ( $taxonomies as $taxonomy ) {
-					if ( ! $taxonomy->public ) {
-						continue;
-					}
-
-					$terms = get_the_terms( $page_id, $taxonomy->name );
-					if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
-						foreach ( $terms as $term ) {
-							$term_link = get_term_link( $term );
-							if ( ! empty( $term_link ) && ! is_wp_error( $term_link ) ) {
-								$term_path = wp_make_link_relative( $term_link );
-								$this->delete_cache_files( $this->get_file_path( $term_path, 'html' ) );
+				$taxonomy_names = get_object_taxonomies( $post_type, 'names' );
+				if ( ! empty( $taxonomy_names ) ) {
+					$all_terms = wp_get_object_terms( $page_id, $taxonomy_names );
+					if ( ! empty( $all_terms ) && ! is_wp_error( $all_terms ) ) {
+						$terms_by_taxonomy = array();
+						foreach ( $all_terms as $term ) {
+							$terms_by_taxonomy[ $term->taxonomy ][] = $term;
+						}
+						foreach ( $terms_by_taxonomy as $taxonomy_name => $terms ) {
+							$taxonomy_obj = get_taxonomy( $taxonomy_name );
+							if ( ! $taxonomy_obj || ! $taxonomy_obj->public ) {
+								continue;
+							}
+							foreach ( $terms as $term ) {
+								$term_link = get_term_link( $term );
+								if ( ! empty( $term_link ) && ! is_wp_error( $term_link ) ) {
+									$term_path = wp_make_link_relative( $term_link );
+									$this->delete_cache_files( $this->get_file_path( $term_path, 'html' ) );
+								}
 							}
 						}
 					}

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -130,7 +130,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 					'post_status'    => 'publish',
 					// phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 					'posts_per_page' => 200, // Process pages in batches to prevent OOM.
-					'offset'         => $paged_offset,
+					'paged'          => max( 1, (int) ceil( ( $paged_offset + 1 ) / 200 ) ),
 					'fields'         => 'ids',
 					'orderby'        => 'ID',
 					'order'          => 'ASC',

--- a/includes/class-database-cleanup.php
+++ b/includes/class-database-cleanup.php
@@ -127,29 +127,44 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Database_Cleanup' ) ) {
 				$has_more            = ( count( $parent_ids ) === 200 );
 
 				foreach ( $parent_ids as $parent_id ) {
-					$wpdb->last_error = '';
-					// Select exactly the cutoff entries so PHP handles almost no object data.
-					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
-					$revisions = $wpdb->get_results(
-						$wpdb->prepare(
-							"SELECT ID, post_date_gmt FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'revision' ORDER BY post_date_gmt DESC LIMIT 500",
-							$parent_id
-						)
-					);
+					$offset     = 0;
+					$first_page = true;
+					$batch_size = 500;
 
-					if ( null === $revisions || ! empty( $wpdb->last_error ) ) {
-						continue;
-					}
+					do {
+						$wpdb->last_error = '';
+						// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+						$revisions = $wpdb->get_results(
+							$wpdb->prepare(
+								"SELECT ID, post_date_gmt FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'revision' ORDER BY post_date_gmt DESC LIMIT %d OFFSET %d",
+								$parent_id,
+								$batch_size,
+								$offset
+							)
+						);
 
-					// Keep the latest X revisions; dump others onto our purge list.
-					$older_revisions = array_slice( $revisions, $keep_latest );
-
-					foreach ( $older_revisions as $rev ) {
-						// Delete if older than cutoff.
-						if ( $rev->post_date_gmt < $cutoff_date_gmt ) {
-							$revisions_to_delete[] = $rev->ID;
+						if ( null === $revisions || ! empty( $wpdb->last_error ) ) {
+							break;
 						}
-					}
+
+						if ( empty( $revisions ) ) {
+							break;
+						}
+
+						// Keep the latest X revisions only on the first page; subsequent pages are all older.
+						$eligible   = $first_page ? array_slice( $revisions, $keep_latest ) : $revisions;
+						$first_page = false;
+
+						foreach ( $eligible as $rev ) {
+							// Delete if older than cutoff.
+							if ( $rev->post_date_gmt < $cutoff_date_gmt ) {
+								$revisions_to_delete[] = $rev->ID;
+							}
+						}
+
+						$offset        += $batch_size;
+						$revision_count = count( $revisions );
+					} while ( $revision_count === $batch_size );
 				}
 
 				if ( ! empty( $revisions_to_delete ) ) {

--- a/includes/class-database-cleanup.php
+++ b/includes/class-database-cleanup.php
@@ -555,7 +555,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Database_Cleanup' ) ) {
 		 */
 		public static function clean_all() {
 			$methods = array(
-				'revisions'          => 'clean_revisions',
+				'revisions'          => 'clean_revisions_advanced',
 				'auto_drafts'        => 'clean_auto_drafts',
 				'trashed_posts'      => 'clean_trashed_posts',
 				'spam_comments'      => 'clean_spam_comments',
@@ -566,7 +566,11 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Database_Cleanup' ) ) {
 
 			$results = array();
 			foreach ( $methods as $key => $method ) {
-				$results[ $key ] = self::invoke_cleanup_method( $method );
+				if ( 'revisions' === $key ) {
+					$results[ $key ] = self::invoke_cleanup_method( $method, 30, 5 );
+				} else {
+					$results[ $key ] = self::invoke_cleanup_method( $method );
+				}
 			}
 
 			return $results;
@@ -703,9 +707,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Database_Cleanup' ) ) {
 			if ( false === $res ) {
 				return new WP_Error( 'db_cleanup_failed', __( 'Database cleanup failed.', 'performance-optimisation' ) );
 			}
-			if ( $res > 0 ) {
-				delete_transient( 'wppo_db_cleanup_counts' );
-			}
+			delete_transient( 'wppo_db_cleanup_counts' );
 			return $res;
 		}
 	}

--- a/includes/class-image-optimisation.php
+++ b/includes/class-image-optimisation.php
@@ -805,6 +805,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 						static $img_size_cache = array();
 
 						if ( ! isset( $img_size_cache[ $local_path ] ) ) {
+							if ( count( $img_size_cache ) >= 100 ) {
+								array_shift( $img_size_cache );
+							}
 							$img_size_cache[ $local_path ] = getimagesize( $local_path );
 						}
 

--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -786,7 +786,6 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 
 			if ( ! self::$img_info_shutdown_registered ) {
 				add_action( 'shutdown', array( __CLASS__, 'commit_img_info' ) );
-				register_shutdown_function( array( __CLASS__, 'commit_img_info' ) );
 				self::$img_info_shutdown_registered = true;
 			}
 		}

--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -786,6 +786,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 
 			if ( ! self::$img_info_shutdown_registered ) {
 				add_action( 'shutdown', array( __CLASS__, 'commit_img_info' ) );
+				register_shutdown_function( array( __CLASS__, 'commit_img_info' ) );
 				self::$img_info_shutdown_registered = true;
 			}
 		}

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -121,12 +121,12 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 			);
 
 			$this->includes();
+			$this->image_optimisation = new Image_Optimisation( $this->options );
 			$this->setup_hooks();
 			$this->filesystem = Util::init_filesystem();
 			if ( ! $this->filesystem ) {
 				$this->filesystem = null;
 			}
-			$this->image_optimisation = new Image_Optimisation( $this->options );
 
 			if ( defined( 'WP_ADMIN' ) ) {
 				new Admin_Notices();

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -202,13 +202,15 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 			}
 
 			if ( ! empty( $this->options['cache']['enableCache'] ) ) {
-				$this->cache = new Cache();
+				$this->cache = new Cache( $this->options );
+				$this->cache->set_image_optimisation( $this->image_optimisation );
 				add_action( 'template_redirect', array( $this->cache, 'generate_dynamic_static_html' ) );
 				add_action( 'save_post', array( $this, 'on_save_post_invalidate_cache' ), 10, 3 );
 			}
 			if ( isset( $this->options['file_optimisation']['combineCSS'] ) && (bool) $this->options['file_optimisation']['combineCSS'] ) {
 				if ( ! $this->cache ) {
-					$this->cache = new Cache();
+					$this->cache = new Cache( $this->options );
+					$this->cache->set_image_optimisation( $this->image_optimisation );
 				}
 				add_action( 'wp_enqueue_scripts', array( $this->cache, 'combine_css' ), PHP_INT_MAX );
 			}
@@ -317,7 +319,21 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 		 * @since 1.2.0
 		 */
 		public static function on_settings_update( $old_value, $value ) {
-			self::clear_all_cache();
+			// Only clear cache when tabs that affect HTML output change.
+			$cache_relevant_tabs = array( 'cache_settings', 'file_optimisation', 'image_optimisation' );
+			$should_clear        = false;
+			foreach ( $cache_relevant_tabs as $tab ) {
+				$old_tab = isset( $old_value[ $tab ] ) ? $old_value[ $tab ] : null;
+				$new_tab = isset( $value[ $tab ] ) ? $value[ $tab ] : null;
+				if ( $old_tab !== $new_tab ) {
+					$should_clear = true;
+					break;
+				}
+			}
+
+			if ( $should_clear ) {
+				self::clear_all_cache();
+			}
 
 			// Handle .htaccess rules update.
 			$old_enable = isset( $old_value['file_optimisation']['enableServerRules'] ) ? (bool) $old_value['file_optimisation']['enableServerRules'] : false;

--- a/includes/class-object-cache.php
+++ b/includes/class-object-cache.php
@@ -94,10 +94,12 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Object_Cache' ) ) {
 			if ( file_exists( $this->dropin_path ) ) {
 				$wp_filesystem = Util::init_filesystem();
 
-				if ( $wp_filesystem ) {
-					$content = $wp_filesystem->get_contents( $this->dropin_path );
-				} elseif ( is_readable( $this->dropin_path ) && filesize( $this->dropin_path ) < 1048576 ) {
-					$content = file_get_contents( $this->dropin_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				if ( is_readable( $this->dropin_path ) && filesize( $this->dropin_path ) < 1048576 ) {
+					if ( $wp_filesystem ) {
+						$content = $wp_filesystem->get_contents( $this->dropin_path );
+					} else {
+						$content = file_get_contents( $this->dropin_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+					}
 				}
 
 				if ( isset( $content ) && is_string( $content ) ) {

--- a/includes/class-object-cache.php
+++ b/includes/class-object-cache.php
@@ -96,7 +96,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Object_Cache' ) ) {
 
 				if ( $wp_filesystem ) {
 					$content = $wp_filesystem->get_contents( $this->dropin_path );
-				} elseif ( is_readable( $this->dropin_path ) ) {
+				} elseif ( is_readable( $this->dropin_path ) && filesize( $this->dropin_path ) < 1048576 ) {
 					$content = file_get_contents( $this->dropin_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 				}
 

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -640,7 +640,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Rest' ) ) {
 			}
 
 			$method_map = array(
-				'revisions'          => 'clean_revisions',
+				'revisions'          => 'clean_revisions_advanced',
 				'auto_drafts'        => 'clean_auto_drafts',
 				'trashed_posts'      => 'clean_trashed_posts',
 				'spam_comments'      => 'clean_spam_comments',
@@ -655,7 +655,11 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Rest' ) ) {
 				return $this->send_response( array( 'deleted' => false ), false, 400, __( 'Invalid cleanup type.', 'performance-optimisation' ) );
 			}
 
-			$result = Database_Cleanup::invoke_cleanup_method( $method );
+			if ( 'revisions' === $type ) {
+				$result = Database_Cleanup::invoke_cleanup_method( $method, 30, 5 );
+			} else {
+				$result = Database_Cleanup::invoke_cleanup_method( $method );
+			}
 
 			if ( is_wp_error( $result ) ) {
 				return $this->send_response( null, false, 500, __( 'Database cleanup failed.', 'performance-optimisation' ) );

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -273,9 +273,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Rest' ) ) {
 
 			$options[ $tab ] = $sanitized_settings;
 
-			if ( update_option( 'wppo_settings', $options ) ) {
-				Cache::clear_cache();
-			}
+			update_option( 'wppo_settings', $options );
 
 			if ( isset( $options['performance_audit'] ) ) {
 				unset( $options['performance_audit']['pagespeed_api_key'] );

--- a/includes/class-telemetry.php
+++ b/includes/class-telemetry.php
@@ -255,51 +255,44 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Telemetry' ) ) {
 			$dom_size = 0;
 
 			if ( class_exists( 'WP_HTML_Tag_Processor' ) ) {
-				// --- DOM Size ---
 				$processor = new \WP_HTML_Tag_Processor( $html );
 				while ( $processor->next_tag() ) {
 					++$dom_size;
-				}
 
-				// --- CSS stylesheets ---
-				$processor = new \WP_HTML_Tag_Processor( $html );
-				while ( $processor->next_tag( array( 'tag_name' => 'LINK' ) ) ) {
-					if ( 'stylesheet' === strtolower( (string) $processor->get_attribute( 'rel' ) ) ) {
-						$href = $processor->get_attribute( 'href' );
-						if ( $href ) {
-							$css[] = (string) $href;
-						}
-					}
-				}
+					switch ( $processor->get_tag() ) {
+						case 'LINK':
+							if ( 'stylesheet' === strtolower( (string) $processor->get_attribute( 'rel' ) ) ) {
+								$href = $processor->get_attribute( 'href' );
+								if ( $href ) {
+									$css[] = (string) $href;
+								}
+							}
+							break;
+						case 'SCRIPT':
+							$src = $processor->get_attribute( 'src' );
+							if ( ! $src ) {
+								$src = $processor->get_attribute( 'wppo-src' );
+							}
+							if ( $src ) {
+								$js[] = (string) $src;
+							}
+							break;
+						case 'IMG':
+							$data_src = $processor->get_attribute( 'data-src' );
+							$src      = $processor->get_attribute( 'src' );
+							$loading  = strtolower( (string) ( $processor->get_attribute( 'loading' ) ?? '' ) );
+							$is_lazy  = ( null !== $data_src ) || ( 'lazy' === $loading );
 
-				// --- Scripts ---
-				$processor = new \WP_HTML_Tag_Processor( $html );
-				while ( $processor->next_tag( array( 'tag_name' => 'SCRIPT' ) ) ) {
-					$src = $processor->get_attribute( 'src' );
-					if ( ! $src ) {
-						$src = $processor->get_attribute( 'wppo-src' );
-					}
-					if ( $src ) {
-						$js[] = (string) $src;
-					}
-				}
+							$resolved_src = $data_src ? (string) $data_src : (string) $src;
 
-				// --- Images ---
-				$processor = new \WP_HTML_Tag_Processor( $html );
-				while ( $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
-					$data_src = $processor->get_attribute( 'data-src' );
-					$src      = $processor->get_attribute( 'src' );
-					$loading  = strtolower( (string) ( $processor->get_attribute( 'loading' ) ?? '' ) );
-					$is_lazy  = ( null !== $data_src ) || ( 'lazy' === $loading );
-
-					$resolved_src = $data_src ? (string) $data_src : (string) $src;
-
-					if ( $resolved_src ) {
-						$images[] = array(
-							'src'  => $resolved_src,
-							'alt'  => $processor->get_attribute( 'alt' ),
-							'lazy' => $is_lazy,
-						);
+							if ( $resolved_src ) {
+								$images[] = array(
+									'src'  => $resolved_src,
+									'alt'  => $processor->get_attribute( 'alt' ),
+									'lazy' => $is_lazy,
+								);
+							}
+							break;
 					}
 				}
 			} else {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'nilesh/performance-optimisation',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => 'b7157f76c51650834c3180168ce8cada9b134295',
+        'reference' => 'da83f8c61c0cc659ea28fde62338190c839992ba',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -40,7 +40,7 @@
         'nilesh/performance-optimisation' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => 'b7157f76c51650834c3180168ce8cada9b134295',
+            'reference' => 'da83f8c61c0cc659ea28fde62338190c839992ba',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Fixes #354

<!-- audit-issue -->

## Audit: performance

**Target directory:** `includes`
**Results:** 0 critical, 4 important, 7 minor

**Summary:** 

### Findings

- **IMPORTANT** `includes/class-cache.php:666` — N+1 query pattern: get_the_terms() called per taxonomy inside invalidate_dynamic_static_html() save_post callback. For a post with 3-4 public taxonomies, this triggers 3-4 separate DB queries on every post save.
  - *Fix:* Collect all term associations in a single query using wp_get_object_terms() with all taxonomy names at once, or cache the term->taxonomy mapping to avoid repeated queries.
- **IMPORTANT** `includes/class-main.php:319` — on_settings_update() unconditionally clears ALL cache via Cache::clear_cache(). Changing any setting (e.g., image quality, lazy load offset) blows every cached page, causing potential cache stampedes on high-traffic sites.
  - *Fix:* Route cache invalidation granularity based on which tab/setting changed: image changes need only next-gen HTML regeneration (not full cache clear), while CSS/JS minification changes should clear combined files.
- **IMPORTANT** `includes/class-database-cleanup.php:557` — clean_all() maps 'revisions' to clean_revisions() which deletes ALL revisions unconditionally (no age cutoff, no keep-latest). The smarter clean_revisions_advanced() with configurable max_age_days/keep_latest exists at line 95 but is only used by auto_clean(). A manual 'clean all' from the REST endpoint will nuke every revision.
  - *Fix:* Map 'revisions' in clean_all() to clean_revisions_advanced() with reasonable defaults (e.g., 30 days, keep 5 latest) to match auto_clean() behavior.
- **IMPORTANT** `includes/class-telemetry.php:258` — parse_resources() instantiates WP_HTML_Tag_Processor 4 times on the same $html string (DOM size, LINK tags, SCRIPT tags, IMG tags). Each pass re-tokenizes the entire HTML DOM independently. On a page with 500+ elements, this is ~4x the required processing.
  - *Fix:* Combine into a single WP_HTML_Tag_Processor pass with a switch on tag_name to populate CSS/JS/images arrays and increment dom_size in one loop.
- **MINOR** `includes/class-cache.php:154` — Cache constructor loads get_option('wppo_settings') on every instantiation, including static calls like Cache::clear_cache() (line 742) and Cache::get_cache_size() (line 805). These static methods do not need the full settings array, but the constructor always reads it.
  - *Fix:* Inject $options as a constructor parameter (already optional via Main) and pass an empty array for static call sites, or move the get_option call to a separate lazy-load accessor.
- **MINOR** `includes/class-object-cache.php:100` — file_get_contents() fallback used to read the object-cache.php drop-in when WP_Filesystem is unavailable. No stream context or chunked reading — the entire file is loaded into memory. While the drop-in is typically small, using file_get_contents directly bypasses WP_Filesystem abstractions.
  - *Fix:* The fallback is acceptable given the drop-in file is typically <10KB. Consider adding a size guard or using file_get_contents with a read limit.
- **MINOR** `includes/class-cron.php:133` — get_posts() uses 'offset' => $paged_offset for pagination in the preload cron. offset-based pagination is O(n) for large offsets because MySQL scans and discards rows. For cron jobs processing batches of 200, this is acceptable but wasteful for sites with 10k+ posts.
  - *Fix:* Replace offset pagination with 'paged' parameter across hidden meta queries, or use cursor-based pagination (WHERE ID > last_processed_id).
- **MINOR** `includes/class-img-converter.php:787` — Deferred image info commit uses add_action('shutdown', ...). The shutdown hook may not fire in all termination contexts: wp_die(), fastcgi_finish_request(), fatal errors, or direct exit() calls will lose queued image info updates.
  - *Fix:* Add a fallback via register_shutdown_function() in addition to the action, or flush the deferred cache on each update_img_info_atomic call with a debounce timer to batch within request timeouts.
- **MINOR** `includes/class-image-optimisation.php:805` — Static $img_size_cache array used to memoize getimagesize() results grows unbounded within a single request. A page with 500+ unique images would hold 500+ entries in the static cache array for the duration of the request.
  - *Fix:* Add a simple cap (e.g., LRU-like limit of 100 entries) or use SplFixedArray if available. In practice, most pages have <100 images, so the risk is low.
- **MINOR** `includes/class-database-cleanup.php:706` — invoke_cleanup_method() deletes the wppo_db_cleanup_counts transient only when $res > 0. If cleanup returns 0 (no items deleted), the stale count persists for the remainder of the 5-minute TTL, causing the UI to show outdated counts.
  - *Fix:* Always delete the transient after cleanup regardless of result, or update it directly with fresh counts.
- **MINOR** `includes/class-cache.php:368` — process_buffer() creates a new Image_Optimisation($this->options) instance on every non-cached page view. The Main class already instantiates Image_Optimisation at line 129, so two instances exist on uncached requests, each duplicating the settings processing, exclusion URL parsing, and class loading overhead.
  - *Fix:* Pass the existing Image_Optimisation instance from Main to Cache, or move the Image_Optimisation processing out of process_buffer() and into a filter applied by Main only when cache is active.

---

Comment `/fix` on this issue to trigger the automated fix workflow.

---
*Auto-generated by opencode-ai-reviewer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation for taxonomy and term pages.
  * Prevented unnecessary cache clearing when unrelated settings are updated.
  * Improved scheduled page preloading and revision cleanup reliability.
  * Added safeguards for large object-cache files.

* **Performance**
  * Reduced repeated image-processing work and capped temporary image metadata caching.
  * Streamlined page resource scanning for faster analysis.

* **Enhancements**
  * Improved debug logging when domain validation fails.
  * Ensured database cleanup results remain current after each operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->