### PR TITLE
⚡ Bolt: Cache excludeDelayJS arrays to avoid parsing on every script tag

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -55,3 +55,7 @@
 ## 2025-01-22 - Redundant Operations in Parsers
 **Learning:** Functions called within high-frequency loops, such as parsing HTML tags, can cause significant performance degradation. Generating regular expressions via `preg_quote` and doing complex URL processing (like `Util::get_local_path`) for each tag or property evaluated can add substantial overhead across a large document.
 **Action:** Lift static computations and string transformations out of loops when parsing. Delay expensive lookups (like resolving local filesystem paths) with lazy evaluation, ensuring they're executed at most once per distinct resource.
+
+## 2025-01-22 - Array Processing in Regex Callback Loops
+**Learning:** Calling array processing operations (like `Util::process_urls`, which filters, maps and unique-ifies arrays) inside high-frequency regex callbacks (like parsing every `<script>` tag on a page for minification or delayJS) can severely impact performance.
+**Action:** When a static or configuration-based array needs to be processed to be used as exclusions or matches inside a regex callback loop, process and cache it once as a class property during instantiation instead of computing it dynamically for each match.

--- a/includes/minify/class-html.php
+++ b/includes/minify/class-html.php
@@ -57,6 +57,14 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Minify\HTML' ) ) {
 		private array $options;
 
 		/**
+		 * Cached array of scripts to exclude from delayJS.
+		 *
+		 * @since 1.7.0
+		 * @var array $exclude_delay_js
+		 */
+		private array $exclude_delay_js;
+
+		/**
 		 * Constructor to initialize HTML minification.
 		 *
 		 * @param string $html The HTML content to minify.
@@ -66,6 +74,14 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Minify\HTML' ) ) {
 		public function __construct( $html, $options ) {
 			$this->options = (array) $options;
 			$this->initialize_minification_settings();
+
+			// Cache delay JS exclusions to avoid redundant processing in loops.
+			$this->exclude_delay_js = array_merge(
+				array( 'wppo-lazyload', 'data-wppo-preserve' ),
+				Util::process_urls( $this->options['file_optimisation']['excludeDelayJS'] ?? array() )
+			);
+			$this->exclude_delay_js = array_values( array_filter( $this->exclude_delay_js, 'strlen' ) );
+
 			$this->minified_html = $this->minify_html( $html );
 		}
 
@@ -318,12 +334,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Minify\HTML' ) ) {
 
 			if ( isset( $this->options['file_optimisation']['delayJS'] ) && (bool) $this->options['file_optimisation']['delayJS'] ) {
 
-				$exclude_delay = array_merge( array( 'wppo-lazyload', 'data-wppo-preserve' ), Util::process_urls( $this->options['file_optimisation']['excludeDelayJS'] ?? array() ) );
-				$exclude_delay = array_values( array_filter( $exclude_delay, 'strlen' ) );
-
 				$should_exclude = false;
-				if ( ! empty( $exclude_delay ) ) {
-					foreach ( $exclude_delay as $exclude ) {
+				if ( ! empty( $this->exclude_delay_js ) ) {
+					foreach ( $this->exclude_delay_js as $exclude ) {
 						if (
 						false !== strpos( $attributes, trim( $exclude ) ) ||
 						false !== strpos( $content, trim( $exclude ) )


### PR DESCRIPTION
💡 What: Lifted `Util::process_urls` out of the `safe_minify_js` callback in `class-html.php` by caching it in a class property (`$exclude_delay_js`) during object instantiation.
🎯 Why: `safe_minify_js` is called via `preg_replace_callback` for *every single script tag* on the page. Processing the exclusion URLs (which involves `explode`, `array_map`, `array_unique`, etc.) dynamically on every single iteration creates a massive, hidden CPU overhead, significantly impacting Time to First Byte (TTFB). 
📊 Impact: Eliminates redundant array processing and string manipulation logic across the entire document parsing loop.
🔬 Measurement: Code syntax verified via `php -l`. Linter warnings fixed via `phpcbf`. Front-end built with `npm run build`. 

---
*PR created automatically by Jules for task [14864065076174802594](https://jules.google.com/task/14864065076174802594) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved JavaScript optimization efficiency by caching exclusion settings instead of recalculating them repeatedly.
  - Preserved existing delayed-minification exclusions while reducing processing overhead during page rendering.

- **Documentation**
  - Added guidance recommending that static configuration values be prepared once rather than recalculated inside frequently executed processing loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->