### PR TITLE
[Autofix] [WP Monitor] Client-Side Media Processing Detection (WP 7.1)

### DIFF
--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -591,6 +591,14 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 		 * @since 1.0.0
 		 */
 		public function convert_image_to_next_gen_format( $metadata, $attachment_id ) {
+
+			// Skip server-side conversion for uploads when WP 7.1+ client-side
+			// media processing handles it in-browser. Batch conversion of
+			// existing media library items remains unaffected.
+			if ( function_exists( 'wp_is_client_side_media_processing_enabled' ) && wp_is_client_side_media_processing_enabled() ) {
+				return $metadata;
+			}
+
 			$upload_dir = wp_upload_dir();
 
 			try {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'nilesh/performance-optimisation',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => '38b0da90addf3ac21fd28f53d1c70df2ec0ee2b5',
+        'reference' => '57a7a163bdadc757674c9594599586861c5f9dd4',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -40,7 +40,7 @@
         'nilesh/performance-optimisation' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => '38b0da90addf3ac21fd28f53d1c70df2ec0ee2b5',
+            'reference' => '57a7a163bdadc757674c9594599586861c5f9dd4',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Fixes #384

## What Was Changed

### What Was Done

Added WP 7.1 client-side media processing detection to skip server-side image conversion during upload when the browser handles it via wasm-vips, while preserving batch conversion for existing media library items.

### Approach

WordPress 7.1 introduces `wp_is_client_side_media_processing_enabled()` — when this returns `true`, newly uploaded images are converted in-browser (WebP/AVIF/HEIC, resizing, thumbnails). The plugin's `convert_image_to_next_gen_format()` method (hooked to `wp_generate_attachment_metadata`) is the upload flow entry point that queues images for server-side conversion. By adding an early return gated on `function_exists()` + `wp_is_client_side_media_processing_enabled()`, we skip redundant server-side processing for uploads only.

The batch/serving flows (`maybe_serve_next_gen_image()`, `replace_image_with_next_gen()`, `add_img_into_queue()`, and the Action Scheduler background job) remain untouched — they continue converting existing media library items on demand. This is fully backward compatible: the `function_exists()` guard ensures no change in behavior on WP < 7.1.

### Key Changes

- **`includes/class-img-converter.php:593`** — Added early return in `convert_image_to_next_gen_format()` when `wp_is_client_side_media_processing_enabled()` is available and returns true, preventing redundant server-side queuing during upload flows.

## Files Changed

- `includes/class-img-converter.php`
- `vendor/composer/installed.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-384`.*