### PR TITLE
[Autofix] [WP Monitor] Full Disable of Own Image Conversion When Core Handles Both WebP and AVIF

### DIFF
--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 				if ( 'webp' === $this->format ) {
 					$this->format = 'none';
 				} elseif ( 'both' === $this->format ) {
-					$this->format = 'avif';
+					$this->format = self::core_handles_both_next_gen() ? 'none' : 'avif';
 				}
 			}
 		}
@@ -120,6 +120,19 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 		 */
 		public static function core_handles_next_gen(): bool {
 			return function_exists( 'wp_image_quality' );
+		}
+
+		/**
+		 * Check if WordPress core (7.1+) natively handles both WebP and AVIF generation.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @return bool True if core can generate both WebP and AVIF natively.
+		 */
+		public static function core_handles_both_next_gen(): bool {
+			return function_exists( 'wp_image_quality' )
+				&& null !== wp_image_quality( 'image/webp' )
+				&& null !== wp_image_quality( 'image/avif' );
 		}
 
 		/**

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'nilesh/performance-optimisation',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => '3e31d8319c6f1db3bd2894e22c9078334f17ee1e',
+        'reference' => 'a873a20f3b172e8406f3012da210152640cc81b1',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -40,7 +40,7 @@
         'nilesh/performance-optimisation' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => '3e31d8319c6f1db3bd2894e22c9078334f17ee1e',
+            'reference' => 'a873a20f3b172e8406f3012da210152640cc81b1',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Fixes #410

## What Was Changed

### What Was Done

Fully disables the plugin's own image conversion during upload when WordPress core natively handles both WebP **and** AVIF generation. Previously, the plugin only skipped WebP conversion (still converting to AVIF) when `wp_image_quality()` existed; now it also checks whether core supports AVIF natively and skips all conversion if both formats are core-native.

### Approach

Added `Img_Converter::core_handles_both_next_gen()` — a static method that returns `true` when `wp_image_quality()` returns non-null for both `image/webp` and `image/avif`. The constructor's existing `core_handles_next_gen()` branch for the `'both'` format now falls through to `core_handles_both_next_gen()`: if both formats are core-native, it sets `$this->format = 'none'` instead of the previous `'avif'` fallback.

The `wp_generate_attachment_metadata` filter is automatically skipped when `get_format()` returns `'none'` (existing logic in `class-image-optimisation.php`). The `wp_get_attachment_image_src` serving filter remains active so previously-converted images in the `wppo/` directory are still served.

### Key Changes

- **`includes/class-img-converter.php:126-137`** — Added `core_handles_both_next_gen()` static method that checks `wp_image_quality()` for both `image/webp` and `image/avif` returning non-null.
- **`includes/class-img-converter.php:109-111`** — Updated constructor: when `core_handles_next_gen()` is true and format is `'both'`, now sets format to `'none'` if `core_handles_both_next_gen()` is also true (avif is only used as fallback when core doesn't natively handle AVIF).

## Files Changed

- `includes/class-img-converter.php`
- `vendor/composer/installed.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-410`.*