### PR TITLE
Add developer action hooks and filters for custom plugin extensibility

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,150 @@
+# Developer Hooks & Filters Reference Guide
+
+The **Performance Optimisation** WordPress plugin provides action hooks and filter hooks allowing developers, agency teams, and custom themes to extend, customize, and override core performance behaviors.
+
+---
+
+## ⚓ Action Hooks
+
+### `wppo_before_cache_clear`
+Fires immediately before the static HTML page cache is cleared.
+
+**Parameters:**
+- `$type` *(string)* — Type of cache clear (`'all'` or `'single_page'`).
+- `$url_path` *(string|null)* — Relative URL path being cleared (if `$type` is `'single_page'`).
+
+**Example:**
+```php
+add_action( 'wppo_before_cache_clear', function( $type, $url_path ) {
+    error_log( "Preparing to clear static cache: {$type} - Path: {$url_path}" );
+}, 10, 2 );
+```
+
+---
+
+### `wppo_after_cache_clear`
+Fires immediately after the static HTML page cache has been successfully cleared.
+
+**Parameters:**
+- `$type` *(string)* — Type of cache clear (`'all'` or `'single_page'`).
+- `$url_path` *(string|null)* — Relative URL path cleared (if `$type` is `'single_page'`).
+
+**Example:**
+```php
+add_action( 'wppo_after_cache_clear', function( $type, $url_path ) {
+    // Notify external CDN or edge proxy (e.g. Cloudflare)
+    if ( 'all' === $type ) {
+        purge_external_cdn_cache();
+    }
+}, 10, 2 );
+```
+
+---
+
+### `wppo_database_cleanup_completed`
+Fires after a database cleanup operation completes.
+
+**Parameters:**
+- `$type` *(string)* — Cleanup type (`'all'`, `'revisions'`, `'auto_drafts'`, `'trashed_posts'`, `'spam_comments'`, `'expired_transients'`, `'orphan_postmeta'`).
+- `$count` *(int)* — Total number of database rows deleted.
+- `$results` *(array|null)* — Detailed per-type cleanup counts when `$type` is `'all'`.
+
+**Example:**
+```php
+add_action( 'wppo_database_cleanup_completed', function( $type, $count ) {
+    error_log( "Performance Optimisation DB Cleanup ({$type}): {$count} rows removed." );
+}, 10, 2 );
+```
+
+---
+
+## 🎛️ Filter Hooks
+
+### `wppo_exclude_delay_js`
+Filters the list of script handles or URL substrings excluded from JavaScript delay loading.
+
+**Parameters:**
+- `$exclusions` *(array)* — Array of excluded script handles/URLs.
+
+**Example:**
+```php
+add_filter( 'wppo_exclude_delay_js', function( $exclusions ) {
+    $exclusions[] = 'my-critical-script-handle';
+    $exclusions[] = 'checkout-tracking.js';
+    return $exclusions;
+} );
+```
+
+---
+
+### `wppo_exclude_defer_js`
+Filters the list of script handles or URL substrings excluded from JavaScript deferral.
+
+**Parameters:**
+- `$exclusions` *(array)* — Array of excluded script handles/URLs.
+
+**Example:**
+```php
+add_filter( 'wppo_exclude_defer_js', function( $exclusions ) {
+    $exclusions[] = 'jquery-core';
+    return $exclusions;
+} );
+```
+
+---
+
+### `wppo_exclude_minification`
+Filters whether a specific CSS or JS file should be skipped during minification.
+
+**Parameters:**
+- `$exclude` *(bool)* — Default `false`. Return `true` to skip minification.
+- `$file_path` *(string)* — Absolute local file path of the asset.
+- `$handle` *(string)* — Registered script or style handle.
+- `$type` *(string)* — Asset type (`'css'` or `'js'`).
+
+**Example:**
+```php
+add_filter( 'wppo_exclude_minification', function( $exclude, $file_path, $handle, $type ) {
+    if ( 'my-custom-slider' === $handle ) {
+        return true; // Skip minification for this handle
+    }
+    return $exclude;
+}, 10, 4 );
+```
+
+---
+
+### `wppo_cache_page_html`
+Filters the pre-rendered HTML content before it is saved to the static cache directory.
+
+**Parameters:**
+- `$html` *(string)* — Pre-rendered HTML string.
+- `$url` *(string)* — Full URL of the page being cached.
+
+**Example:**
+```php
+add_filter( 'wppo_cache_page_html', function( $html, $url ) {
+    // Inject custom HTML signature comment
+    return $html . "\n<!-- Cached by Performance Optimisation at " . date( 'c' ) . " -->";
+}, 10, 2 );
+```
+
+---
+
+### `wppo_lazyload_iframe_allowed`
+Filters whether a specific `<iframe>` element should be processed for lazy loading.
+
+**Parameters:**
+- `$allowed` *(bool)* — Default `true`. Return `false` to disable lazy loading for this iframe.
+- `$src` *(string)* — Source URL of the iframe.
+- `$iframe_tag` *(string)* — Full raw HTML of the iframe tag.
+
+**Example:**
+```php
+add_filter( 'wppo_lazyload_iframe_allowed', function( $allowed, $src, $iframe_tag ) {
+    if ( false !== strpos( $src, 'google.com/maps' ) ) {
+        return false; // Do not lazy load embedded Google Maps
+    }
+    return $allowed;
+}, 10, 3 );
+```

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -645,6 +645,11 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 				return;
 			}
 
+			if ( 'html' === $type ) {
+				$current_url = home_url( $this->request_uri );
+				$buffer      = apply_filters( 'wppo_cache_page_html', $buffer, $current_url );
+			}
+
 			$gzip_file_path = $file_path . '.gz';
 
 			$fs = $this->get_filesystem();
@@ -850,6 +855,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 		 * @since 1.1.1
 		 */
 		public static function clear_cache( $url_path = null ): bool {
+			$type = $url_path ? 'single_page' : 'all';
+			do_action( 'wppo_before_cache_clear', $type, $url_path );
+
 			$instance = new self();
 
 			if ( ! $instance->get_filesystem() ) {
@@ -885,6 +893,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 					delete_transient( 'wppo_cache_size' );
 					delete_transient( 'wppo_total_js_css' );
 				}
+				do_action( 'wppo_after_cache_clear', $type, $url_path );
 			}
 
 			return $result;

--- a/includes/class-database-cleanup.php
+++ b/includes/class-database-cleanup.php
@@ -587,14 +587,22 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Database_Cleanup' ) ) {
 				'orphan_postmeta'    => 'clean_orphan_postmeta',
 			);
 
-			$results = array();
+			$results       = array();
+			$total_deleted = 0;
+
 			foreach ( $methods as $key => $method ) {
 				if ( 'revisions' === $key ) {
-					$results[ $key ] = self::invoke_cleanup_method( $method, 30, 5 );
+					$res = self::invoke_cleanup_method( $method, 30, 5 );
 				} else {
-					$results[ $key ] = self::invoke_cleanup_method( $method );
+					$res = self::invoke_cleanup_method( $method );
+				}
+				$results[ $key ] = $res;
+				if ( ! is_wp_error( $res ) && false !== $res ) {
+					$total_deleted += (int) $res;
 				}
 			}
+
+			do_action( 'wppo_database_cleanup_completed', 'all', $total_deleted, $results );
 
 			return $results;
 		}

--- a/includes/class-image-optimisation.php
+++ b/includes/class-image-optimisation.php
@@ -1076,12 +1076,18 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 		 * @return string The modified `<iframe>` tag HTML.
 		 */
 		public function process_iframe_tag( $iframe_tag, $original_src, $exclude_imgs ) {
-			foreach ( $exclude_imgs as $exclude_img ) {
-				if ( false !== strpos( $original_src, $exclude_img ) ) {
-					return $iframe_tag;
+			if ( ! empty( $exclude_imgs ) ) {
+				foreach ( $exclude_imgs as $exclude_img ) {
+					if ( false !== strpos( $original_src, $exclude_img ) ) {
+						return $iframe_tag;
+					}
 				}
 			}
 
+			$allowed = apply_filters( 'wppo_lazyload_iframe_allowed', true, $original_src, $iframe_tag );
+			if ( ! $allowed ) {
+				return $iframe_tag;
+			}
 			if ( class_exists( 'WP_HTML_Tag_Processor' ) ) {
 				$tags = new \WP_HTML_Tag_Processor( $iframe_tag );
 				if ( $tags->next_tag( array( 'tag_name' => 'iframe' ) ) ) {

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -283,6 +283,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				} else {
 					$this->exclude_defer_js = $exclude_js;
 				}
+				$this->exclude_defer_js = apply_filters( 'wppo_exclude_defer_js', $this->exclude_defer_js );
 			}
 
 			if ( ! empty( $this->options['file_optimisation']['delayJS'] ) ) {
@@ -293,6 +294,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				} else {
 					$this->exclude_delay_js = $exclude_js;
 				}
+				$this->exclude_delay_js = apply_filters( 'wppo_exclude_delay_js', $this->exclude_delay_js );
 			}
 
 			add_action( 'wp_head', array( $this, 'add_preload_prefetch_preconnect' ), 1 );
@@ -1119,12 +1121,19 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				return $tag;
 			}
 
+			$local_path = Util::get_local_path( $href );
+			if ( empty( $local_path ) ) {
+				return $tag;
+			}
+
+			if ( apply_filters( 'wppo_exclude_minification', false, $local_path, $handle, 'css' ) ) {
+				return $tag;
+			}
+
 			// Early return if the URL already indicates a minified file.
 			if ( $this->is_minified_asset_name( $href, 'css' ) ) {
 				return $tag;
 			}
-
-			$local_path = Util::get_local_path( $href );
 
 			if ( $this->is_css_minified( $local_path ) ) {
 				return $tag;
@@ -1160,12 +1169,19 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				return $tag;
 			}
 
+			$local_path = Util::get_local_path( $src );
+			if ( empty( $local_path ) ) {
+				return $tag;
+			}
+
+			if ( apply_filters( 'wppo_exclude_minification', false, $local_path, $handle, 'js' ) ) {
+				return $tag;
+			}
+
 			// Early return if the URL already indicates a minified file.
 			if ( $this->is_minified_asset_name( $src, 'js' ) ) {
 				return $tag;
 			}
-
-			$local_path = Util::get_local_path( $src );
 
 			if ( $this->is_js_minified( $local_path ) ) {
 				return $tag;

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,7 @@ See the complete methodology and detailed desktop/mobile breakdown in [PERFORMAN
   - `wp wppo settings get [<tab>]`
   - `wp wppo settings update <tab> --settings=<json>`
   - `wp wppo object-cache flush`
+- **Developer Action Hooks & Filters:** Easily extend plugin behavior with standard WordPress hooks (`wppo_before_cache_clear`, `wppo_after_cache_clear`, `wppo_exclude_delay_js`, `wppo_exclude_defer_js`, `wppo_exclude_minification`, `wppo_cache_page_html`, `wppo_lazyload_iframe_allowed`, `wppo_database_cleanup_completed`). See the full [Developer Hooks Reference](docs/hooks.md).
 
 ### Compatibility & Ecosystem
 


### PR DESCRIPTION
Fixes #379

## Summary
- Added developer action hooks and filter hooks across the codebase:
  - `wppo_exclude_delay_js` — Filter script handles/URLs excluded from delay loading.
  - `wppo_exclude_defer_js` — Filter script handles/URLs excluded from defer loading.
  - `wppo_exclude_minification` — Filter files skipped during CSS/JS minification.
  - `wppo_cache_page_html` — Filter pre-rendered HTML before saving static cache file.
  - `wppo_lazyload_iframe_allowed` — Filter iframe lazyload inclusion per iframe tag.
  - `wppo_before_cache_clear` — Action hook fired before static HTML cache clear.
  - `wppo_after_cache_clear` — Action hook fired after static HTML cache clear completes.
  - `wppo_database_cleanup_completed` — Action hook fired after database cleanup operations.
- Created comprehensive developer reference guide `docs/hooks.md` and linked from `readme.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added developer hooks and filters for cache clearing, database cleanup, HTML caching, script exclusions, minification, and iframe lazy-loading.
  * Added greater control over which CSS and JavaScript assets are minified or deferred.

* **Documentation**
  * Added a comprehensive developer hooks and filters reference with usage examples.
  * Updated the administrative tools documentation to link to the new reference guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->