### PR TITLE
[Autofix] 🔧 Improvement: Better Minification Detection Heuristic

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -1169,24 +1169,41 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				return true;
 			}
 
+			$file_size = filesize( $file_path );
+			if ( false === $file_size ) {
+				return true;
+			}
+
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 			$handle = fopen( $file_path, 'r' );
 			if ( ! $handle ) {
 				return true;
 			}
 
-			$line_count = 0;
+			$line_count  = 0;
+			$total_chars = 0;
+			$max_lines   = 50;
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fgets
-			while ( false !== fgets( $handle ) ) {
+			$line = fgets( $handle );
+			while ( false !== $line ) {
 				++$line_count;
-				if ( $line_count > 10 ) {
+				$total_chars += strlen( $line );
+				if ( $line_count >= $max_lines ) {
 					break;
 				}
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fgets
+				$line = fgets( $handle );
 			}
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			fclose( $handle );
 
-			$is_minified = 10 >= $line_count;
+			$avg_line_length = $total_chars / max( 1, $line_count );
+			$threshold       = 'css' === $type ? 500 : 1000;
+
+			$is_minified = $line_count <= 1
+				|| ( $line_count <= 3 && $file_size > 1000 )
+				|| $avg_line_length > $threshold;
+
 			wp_cache_set( $cache_key, (int) $is_minified, $cache_group, HOUR_IN_SECONDS );
 
 			return $is_minified;

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'nilesh/performance-optimisation',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => '9ba7d26c05b7e508860800ba004a01f914b0c66a',
+        'reference' => 'b3fee5c803e56e732a7cd2dcfc53d34579e394f8',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -40,7 +40,7 @@
         'nilesh/performance-optimisation' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => '9ba7d26c05b7e508860800ba004a01f914b0c66a',
+            'reference' => 'b3fee5c803e56e732a7cd2dcfc53d34579e394f8',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Fixes #432

## What Was Changed

### What Was Done

Replaced the naive line-count heuristic in `is_file_minified()` with a multi-factor detection algorithm that checks average line length, file size vs line count ratio, and single-line files — reducing false positives/negatives for CSS/JS minification decisions.

### Approach

The previous heuristic considered any file with ≤10 lines as minified. This caused false positives (short readable files being double-minified) and false negatives (minified files with >10 line breaks being missed).

The new heuristic computes three metrics after reading up to 50 lines:
1. **Single-line files** (`$line_count <= 1`) — almost certainly minified/bundled
2. **Few lines + large size** (`$line_count <= 3 && $file_size > 1000`) — indicates dense content compressed into few lines
3. **Average line length** (`$avg_line_length > 500` for CSS, `> 1000` for JS) — minified files consistently have very long lines

The `filesize()` call and `strlen()` accumulation add negligible overhead since the file is already opened for reading, and results are still cached via `wp_cache`.

### Key Changes

- **`includes/class-main.php:1150-1193`** — `is_file_minified()`: Replaced the `10 >= $line_count` check with a composite heuristic using `filesize()`, accumulated character length, and average line length. Extended the read loop from 11 to 50 lines for a representative sample. Added `$file_size` early return guard for unreadable files.

## Files Changed

- `includes/class-main.php`
- `vendor/composer/installed.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-432`.*