### PR TITLE
[Autofix] 🔧 Improvement: Multisite Cache Key Isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,15 @@ Namespace `performance-optimisation/v1`, defined in `includes/class-rest.php` (2
 - All REST endpoints require `manage_options` + `X-WP-Nonce`
 - Settings stored as serialized array in single `wppo_settings` option
 
+## Multisite compatibility
+
+- **Transient key isolation**: All plugin transient keys are prefixed with `{blog_id}_` on multisite networks via `Util::transient_key()` to prevent collisions when a shared object cache backend (Redis, Memcached) is present.
+- **Static HTML cache**: Uses domain-based directory structure (`{domain}/{path}/index.html`) — inherently multisite-safe.
+- **Redis drop-in** (`templates/object-cache.php`): Uses `get_current_blog_id()` for key namespacing via `blog_prefix`.
+- **Options** (`wppo_settings`, `wppo_img_info`, etc.): WordPress `get_option`/`update_option` is inherently site-specific in multisite.
+- **Database queries**: Use `$wpdb->posts` (etc.), which are multisite-safe via table prefix.
+- **Uninstall**: Inline blog-ID prefixing for transient deletion when iterating sites with `switch_to_blog()`.
+
 ## Build
 
 - No custom Webpack config — uses `@wordpress/scripts` defaults

--- a/includes/class-activate.php
+++ b/includes/class-activate.php
@@ -53,9 +53,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Activate' ) ) {
 			}
 
 			if ( ! empty( $notices ) ) {
-				set_transient( 'wppo_activation_notices', array_unique( $notices ), WEEK_IN_SECONDS );
+				set_transient( Util::transient_key( 'wppo_activation_notices' ), array_unique( $notices ), WEEK_IN_SECONDS );
 			} else {
-				delete_transient( 'wppo_activation_notices' );
+				delete_transient( Util::transient_key( 'wppo_activation_notices' ) );
 			}
 
 			if ( ! get_option( 'wppo_activation_time' ) ) {
@@ -69,7 +69,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Activate' ) ) {
 				$rules_updated = Htaccess_Handler::update_rules( true );
 				if ( ! $rules_updated ) {
 					$notices[] = __( 'Failed to update .htaccess rules during activation.', 'performance-optimisation' );
-					set_transient( 'wppo_activation_notices', array_unique( $notices ), WEEK_IN_SECONDS );
+					set_transient( Util::transient_key( 'wppo_activation_notices' ), array_unique( $notices ), WEEK_IN_SECONDS );
 				}
 			}
 

--- a/includes/class-admin-notices.php
+++ b/includes/class-admin-notices.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Admin_Notices' ) ) {
 			$key = sanitize_key( wp_unslash( $_GET['wppo_dismiss'] ) );
 
 			if ( 'activation' === $key ) {
-				delete_transient( 'wppo_activation_notices' );
+				delete_transient( Util::transient_key( 'wppo_activation_notices' ) );
 			}
 
 			if ( 'review_done' === $key ) {
@@ -102,7 +102,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Admin_Notices' ) ) {
 		 * @return void
 		 */
 		private function maybe_activation_notices(): void {
-			$notices = get_transient( 'wppo_activation_notices' );
+			$notices = get_transient( Util::transient_key( 'wppo_activation_notices' ) );
 
 			if ( ! is_array( $notices ) || empty( $notices ) ) {
 				return;

--- a/includes/class-asset-manager.php
+++ b/includes/class-asset-manager.php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Asset_Manager' ) ) {
 
 			if ( $has_changed ) {
 				// Store for 24 hours, keyed by post ID.
-				set_transient( self::TRANSIENT_PREFIX . $post_id, $assets, DAY_IN_SECONDS );
+				set_transient( Util::transient_key( self::TRANSIENT_PREFIX . $post_id ), $assets, DAY_IN_SECONDS );
 			}
 		}
 
@@ -207,7 +207,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Asset_Manager' ) ) {
 		 * @return array|false The captured assets array, or false if not found.
 		 */
 		public static function get_page_assets( $post_id ) {
-			return get_transient( self::TRANSIENT_PREFIX . $post_id );
+			return get_transient( Util::transient_key( self::TRANSIENT_PREFIX . $post_id ) );
 		}
 
 		/**

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -950,8 +950,8 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 					$salt = (int) get_option( 'wppo_cache_last_cleared', 0 ) + 1;
 					update_option( 'wppo_cache_last_cleared', $salt, false );
 				} else {
-					delete_transient( 'wppo_cache_size' );
-					delete_transient( 'wppo_total_js_css' );
+					delete_transient( Util::transient_key( 'wppo_cache_size' ) );
+					delete_transient( Util::transient_key( 'wppo_total_js_css' ) );
 				}
 				do_action( 'wppo_after_cache_clear', $type, $url_path );
 			}

--- a/includes/class-critical-css.php
+++ b/includes/class-critical-css.php
@@ -217,7 +217,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Critical_CSS' ) ) {
 						'label'  => $label,
 					);
 				} else {
-					$cache_status      = get_transient( 'wppo_ccss_status_' . $hash );
+					$cache_status      = get_transient( Util::transient_key( 'wppo_ccss_status_' . $hash ) );
 					$statuses[ $hash ] = array(
 						'status' => $cache_status ? $cache_status : 'none',
 						'label'  => $label,
@@ -760,19 +760,19 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Critical_CSS' ) ) {
 		private static function generate_and_store( string $template_hash, string $template ): bool {
 			$url = self::get_sample_url( $template );
 			if ( ! $url ) {
-				set_transient( 'wppo_ccss_status_' . $template_hash, 'failed', DAY_IN_SECONDS );
+				set_transient( Util::transient_key( 'wppo_ccss_status_' . $template_hash ), 'failed', DAY_IN_SECONDS );
 				return false;
 			}
 
 			$critical_css = self::generate( $url );
 			if ( false === $critical_css ) {
-				set_transient( 'wppo_ccss_status_' . $template_hash, 'failed', DAY_IN_SECONDS );
+				set_transient( Util::transient_key( 'wppo_ccss_status_' . $template_hash ), 'failed', DAY_IN_SECONDS );
 				return false;
 			}
 
 			$dir = self::get_ccss_dir();
 			if ( ! wp_mkdir_p( $dir ) ) {
-				set_transient( 'wppo_ccss_status_' . $template_hash, 'failed', DAY_IN_SECONDS );
+				set_transient( Util::transient_key( 'wppo_ccss_status_' . $template_hash ), 'failed', DAY_IN_SECONDS );
 				return false;
 			}
 
@@ -785,11 +785,11 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Critical_CSS' ) ) {
 			}
 
 			if ( file_exists( self::get_ccss_file( $template_hash ) ) ) {
-				set_transient( 'wppo_ccss_status_' . $template_hash, 'ready', WEEK_IN_SECONDS );
+				set_transient( Util::transient_key( 'wppo_ccss_status_' . $template_hash ), 'ready', WEEK_IN_SECONDS );
 				return true;
 			}
 
-			set_transient( 'wppo_ccss_status_' . $template_hash, 'failed', DAY_IN_SECONDS );
+			set_transient( Util::transient_key( 'wppo_ccss_status_' . $template_hash ), 'failed', DAY_IN_SECONDS );
 			return false;
 		}
 
@@ -827,7 +827,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Critical_CSS' ) ) {
 						array( 'template_hash' => $template_hash ),
 						'performance_optimisation'
 					);
-					set_transient( 'wppo_ccss_status_' . $template_hash, 'pending', HOUR_IN_SECONDS );
+					set_transient( Util::transient_key( 'wppo_ccss_status_' . $template_hash ), 'pending', HOUR_IN_SECONDS );
 				}
 			}
 		}
@@ -899,7 +899,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Critical_CSS' ) ) {
 			}
 
 			if ( empty( $found_template ) ) {
-				set_transient( 'wppo_ccss_status_' . $template_hash, 'failed', DAY_IN_SECONDS );
+				set_transient( Util::transient_key( 'wppo_ccss_status_' . $template_hash ), 'failed', DAY_IN_SECONDS );
 				return;
 			}
 
@@ -949,7 +949,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Critical_CSS' ) ) {
 						++$queued;
 					}
 				}
-				set_transient( 'wppo_ccss_status_' . $hash, 'pending', HOUR_IN_SECONDS );
+				set_transient( Util::transient_key( 'wppo_ccss_status_' . $hash ), 'pending', HOUR_IN_SECONDS );
 			}
 
 			Log::add(
@@ -983,7 +983,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Critical_CSS' ) ) {
 			$templates = self::get_templates();
 			foreach ( $templates as $template => $label ) {
 				$hash = self::get_template_hash( $template );
-				delete_transient( 'wppo_ccss_status_' . $hash );
+				delete_transient( Util::transient_key( 'wppo_ccss_status_' . $hash ) );
 			}
 		}
 	}

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -141,10 +141,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 		 */
 		private function schedule_page_cron_jobs(): void {
 			// Transient-based lock to prevent concurrent workers from duplicating or skipping work.
-			if ( get_transient( 'wppo_preload_cron_lock' ) ) {
+			if ( get_transient( Util::transient_key( 'wppo_preload_cron_lock' ) ) ) {
 				return;
 			}
-			set_transient( 'wppo_preload_cron_lock', 1, 20 * MINUTE_IN_SECONDS );
+			set_transient( Util::transient_key( 'wppo_preload_cron_lock' ), 1, 20 * MINUTE_IN_SECONDS );
 
 			try {
 				// Persist iteration offset across runs.
@@ -219,7 +219,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 					wp_schedule_single_event( time() + 60, 'wppo_page_cron_batch' );
 				}
 			} finally {
-				delete_transient( 'wppo_preload_cron_lock' );
+				delete_transient( Util::transient_key( 'wppo_preload_cron_lock' ) );
 			}
 		}
 
@@ -230,10 +230,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 		 * @since 1.9.0
 		 */
 		public function used_css_cron() {
-			if ( get_transient( 'wppo_used_css_lock' ) ) {
+			if ( get_transient( Util::transient_key( 'wppo_used_css_lock' ) ) ) {
 				return;
 			}
-			set_transient( 'wppo_used_css_lock', 1, 20 * MINUTE_IN_SECONDS );
+			set_transient( Util::transient_key( 'wppo_used_css_lock' ), 1, 20 * MINUTE_IN_SECONDS );
 
 			try {
 				$options = get_option( 'wppo_settings', array() );
@@ -244,7 +244,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 				$used_css = new Used_CSS( $options );
 				$used_css->regenerate_all();
 			} finally {
-				delete_transient( 'wppo_used_css_lock' );
+				delete_transient( Util::transient_key( 'wppo_used_css_lock' ) );
 			}
 		}
 
@@ -259,9 +259,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 			wp_clear_scheduled_hook( 'wppo_page_cron_hook' );
 			wp_clear_scheduled_hook( 'wppo_page_cron_batch' );
 			delete_option( 'wppo_preload_cron_offset' );
-			delete_transient( 'wppo_preload_cron_lock' );
+			delete_transient( Util::transient_key( 'wppo_preload_cron_lock' ) );
 			wp_clear_scheduled_hook( 'wppo_used_css_cron' );
-			delete_transient( 'wppo_used_css_lock' );
+			delete_transient( Util::transient_key( 'wppo_used_css_lock' ) );
 			wp_clear_scheduled_hook( 'wppo_ccss_regeneration' );
 			wp_clear_scheduled_hook( 'wppo_generate_ccss' );
 		}
@@ -353,10 +353,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 		 * @since 1.0.0
 		 */
 		public function img_convert_cron() {
-			if ( get_transient( 'wppo_img_convert_lock' ) ) {
+			if ( get_transient( Util::transient_key( 'wppo_img_convert_lock' ) ) ) {
 				return;
 			}
-			set_transient( 'wppo_img_convert_lock', true, 5 * MINUTE_IN_SECONDS );
+			set_transient( Util::transient_key( 'wppo_img_convert_lock' ), true, 5 * MINUTE_IN_SECONDS );
 
 			try {
 				$options       = get_option( 'wppo_settings', array() );
@@ -402,7 +402,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 					}
 				}
 			} finally {
-				delete_transient( 'wppo_img_convert_lock' );
+				delete_transient( Util::transient_key( 'wppo_img_convert_lock' ) );
 			}
 		}
 
@@ -442,14 +442,14 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cron' ) ) {
 
 			if ( $should_run ) {
 				// Use transient-based lock as primary mechanism (works without persistent object cache).
-				if ( get_transient( 'wppo_db_cleanup_lock' ) ) {
+				if ( get_transient( Util::transient_key( 'wppo_db_cleanup_lock' ) ) ) {
 					return;
 				}
-				set_transient( 'wppo_db_cleanup_lock', 1, 5 * MINUTE_IN_SECONDS );
+				set_transient( Util::transient_key( 'wppo_db_cleanup_lock' ), 1, 5 * MINUTE_IN_SECONDS );
 				try {
 					Database_Cleanup::auto_clean( $settings );
 				} finally {
-					delete_transient( 'wppo_db_cleanup_lock' );
+					delete_transient( Util::transient_key( 'wppo_db_cleanup_lock' ) );
 				}
 				update_option( 'wppo_last_db_cleanup', $now, false );
 			}

--- a/includes/class-database-cleanup.php
+++ b/includes/class-database-cleanup.php
@@ -682,7 +682,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Database_Cleanup' ) ) {
 					return $cached;
 				}
 			} else {
-				$cached = get_transient( 'wppo_db_cleanup_counts' );
+				$cached = get_transient( Util::transient_key( 'wppo_db_cleanup_counts' ) );
 				if ( false !== $cached ) {
 					return $cached;
 				}
@@ -733,7 +733,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Database_Cleanup' ) ) {
 			if ( $has_salted ) {
 				wp_cache_set_salted( 'wppo_db_cleanup_counts', $counts, 'wppo', self::SALT_KEY );
 			} else {
-				set_transient( 'wppo_db_cleanup_counts', $counts, 5 * MINUTE_IN_SECONDS );
+				set_transient( Util::transient_key( 'wppo_db_cleanup_counts' ), $counts, 5 * MINUTE_IN_SECONDS );
 			}
 			return $counts;
 		}
@@ -765,7 +765,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Database_Cleanup' ) ) {
 			if ( function_exists( 'wp_cache_get_salted' ) ) {
 				update_option( self::SALT_KEY, time(), false );
 			} else {
-				delete_transient( 'wppo_db_cleanup_counts' );
+				delete_transient( Util::transient_key( 'wppo_db_cleanup_counts' ) );
 			}
 		}
 

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -381,7 +381,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 			}
 
 			// Only run this check once per hour to avoid constant I/O.
-			if ( get_transient( 'wppo_wp_cache_fix_checked' ) ) {
+			if ( get_transient( Util::transient_key( 'wppo_wp_cache_fix_checked' ) ) ) {
 				return;
 			}
 
@@ -389,14 +389,14 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 			$notices = Activate::add_wp_cache_constant();
 
 			// Always throttle for 1 hour to avoid constant I/O on failure.
-			set_transient( 'wppo_wp_cache_fix_checked', 1, HOUR_IN_SECONDS );
+			set_transient( Util::transient_key( 'wppo_wp_cache_fix_checked' ), 1, HOUR_IN_SECONDS );
 
 			if ( ! empty( $notices ) ) {
 				// Failure — merge notice keys into existing transient to notify user immediately.
-				$existing_notices = get_transient( 'wppo_activation_notices' );
+				$existing_notices = get_transient( Util::transient_key( 'wppo_activation_notices' ) );
 				$existing_notices = is_array( $existing_notices ) ? $existing_notices : array();
 				$new_notices      = array_unique( array_merge( $existing_notices, (array) $notices ) );
-				set_transient( 'wppo_activation_notices', $new_notices, 30 );
+				set_transient( Util::transient_key( 'wppo_activation_notices' ), $new_notices, 30 );
 			}
 		}
 
@@ -780,10 +780,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 					wp_cache_set_salted( 'wppo_cache_size', $cache_size, 'wppo', $cache_salt_key );
 				}
 			} else {
-				$cache_size = get_transient( 'wppo_cache_size' );
+				$cache_size = get_transient( Util::transient_key( 'wppo_cache_size' ) );
 				if ( false === $cache_size ) {
 					$cache_size = Cache::get_cache_size();
-					set_transient( 'wppo_cache_size', $cache_size, 15 * MINUTE_IN_SECONDS );
+					set_transient( Util::transient_key( 'wppo_cache_size' ), $cache_size, 15 * MINUTE_IN_SECONDS );
 				}
 			}
 
@@ -794,10 +794,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 					wp_cache_set_salted( 'wppo_total_js_css', $total_js_css, 'wppo', $cache_salt_key );
 				}
 			} else {
-				$total_js_css = get_transient( 'wppo_total_js_css' );
+				$total_js_css = get_transient( Util::transient_key( 'wppo_total_js_css' ) );
 				if ( false === $total_js_css ) {
 					$total_js_css = Util::get_js_css_minified_file();
-					set_transient( 'wppo_total_js_css', $total_js_css, 15 * MINUTE_IN_SECONDS );
+					set_transient( Util::transient_key( 'wppo_total_js_css' ), $total_js_css, 15 * MINUTE_IN_SECONDS );
 				}
 			}
 

--- a/includes/class-pagespeed.php
+++ b/includes/class-pagespeed.php
@@ -264,7 +264,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Pagespeed' ) ) {
 		 * @return string Transient key.
 		 */
 		public static function get_transient_key( string $url, string $strategy ): string {
-			return 'wppo_pagespeed_' . md5( esc_url_raw( $url ) ) . '_' . sanitize_key( $strategy );
+			return Util::transient_key( 'wppo_pagespeed_' . md5( esc_url_raw( $url ) ) . '_' . sanitize_key( $strategy ) );
 		}
 
 		/**

--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -1248,7 +1248,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Rest' ) ) {
 			$params = $request->get_params();
 			$url    = isset( $params['url'] ) ? esc_url_raw( $params['url'] ) : home_url( '/' );
 
-			$transient_key = 'wppo_audit_' . md5( $url );
+			$transient_key = Util::transient_key( 'wppo_audit_' . md5( $url ) );
 			$telemetry     = get_transient( $transient_key );
 
 			if ( false === $telemetry ) {

--- a/includes/class-telemetry.php
+++ b/includes/class-telemetry.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Telemetry' ) ) {
 		 * @return array|\WP_Error   Associative array of metrics, or WP_Error on failure.
 		 */
 		public static function scan( string $url, string $scan_type = 'manual', bool $force = false ): array|\WP_Error {
-			$cache_key  = 'wppo_audit_' . md5( $url );
+			$cache_key  = Util::transient_key( 'wppo_audit_' . md5( $url ) );
 			$has_salted = function_exists( 'wp_cache_get_salted' );
 
 			if ( $has_salted ) {

--- a/includes/class-util.php
+++ b/includes/class-util.php
@@ -265,5 +265,20 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Util' ) ) {
 			}
 			return array_values( array_filter( array_unique( array_map( 'trim', explode( "\n", (string) $urls ) ) ) ) );
 		}
+
+		/**
+		 * Qualify a transient key with the current blog ID on multisite.
+		 *
+		 * Prevents transient key collisions when a shared object cache backend
+		 * (Redis, Memcached) is present. On single-site installs the key is
+		 * returned unchanged.
+		 *
+		 * @param string $key The bare transient key.
+		 * @return string Blog-ID-prefixed key on multisite, or the original key.
+		 * @since 2.6.0
+		 */
+		public static function transient_key( string $key ): string {
+			return is_multisite() ? (string) get_current_blog_id() . '_' . $key : $key;
+		}
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -78,11 +78,12 @@ if ( ! function_exists( 'wppo_cleanup_site' ) ) {
 		delete_user_meta_by_key( 'wppo_welcome_dismissed' );
 
 		// Delete transients.
-		delete_transient( 'wppo_activation_notices' );
-		delete_transient( 'wppo_show_welcome_notice' );
-		delete_transient( 'wppo_cache_size' );
-		delete_transient( 'wppo_total_js_css' );
-		delete_transient( 'wppo_wp_cache_fix_checked' );
+		$transient_prefix = is_multisite() ? get_current_blog_id() . '_' : '';
+		delete_transient( $transient_prefix . 'wppo_activation_notices' );
+		delete_transient( $transient_prefix . 'wppo_show_welcome_notice' );
+		delete_transient( $transient_prefix . 'wppo_cache_size' );
+		delete_transient( $transient_prefix . 'wppo_total_js_css' );
+		delete_transient( $transient_prefix . 'wppo_wp_cache_fix_checked' );
 	}
 }
 

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'nilesh/performance-optimisation',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => 'b5a66ecfa28cf8cc979ec859788e5eb02f57ceef',
+        'reference' => '8b050f2d6d39a86d58c70d38a1284b5f1cbc0681',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -40,7 +40,7 @@
         'nilesh/performance-optimisation' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => 'b5a66ecfa28cf8cc979ec859788e5eb02f57ceef',
+            'reference' => '8b050f2d6d39a86d58c70d38a1284b5f1cbc0681',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Fixes #437

## What Was Changed

### What Was Done

Added multisite cache key isolation by prefixing all plugin transient keys with the current blog ID on WordPress Multisite networks. This prevents transient collisions when a shared persistent object cache (Redis, Memcached) is present across sites.

### Approach

Introduced a `Util::transient_key()` helper that conditionally prepends `{blog_id}_` to any transient key on multisite installs. All 36 `get_transient`/`set_transient`/`delete_transient` call sites across 10 files were updated to wrap their key strings through this helper. The uninstall script uses inline prefixing since it runs outside the plugin lifecycle. The Redis drop-in already handled blog-ID namespacing correctly and needed no changes.

### Key Changes

- **`includes/class-util.php`** — Added `Util::transient_key()` static method: wraps a key with `{blog_id}_` on multisite, returns unchanged on single-site.
- **`includes/class-main.php`** — Wrapped 8 transient keys (`wppo_wp_cache_fix_checked`, `wppo_activation_notices`, `wppo_cache_size`, `wppo_total_js_css`).
- **`includes/class-cache.php`** — Wrapped 2 `delete_transient` calls for cache size transients.
- **`includes/class-database-cleanup.php`** — Wrapped 3 occurrences of `wppo_db_cleanup_counts`.
- **`includes/class-activate.php`** — Wrapped 3 occurrences of `wppo_activation_notices`.
- **`includes/class-admin-notices.php`** — Wrapped 2 occurrences of `wppo_activation_notices`.
- **`includes/class-cron.php`** — Wrapped 14 occurrences (preload/used-css/img-convert/db-cleanup lock transients).
- **`includes/class-telemetry.php`** — Wrapped dynamic `wppo_audit_` key construction.
- **`includes/class-pagespeed.php`** — Wrapped `get_transient_key()` return value, covering 3 call sites.
- **`includes/class-critical-css.php`** — Wrapped 10 occurrences of `wppo_ccss_status_` keys.
- **`includes/class-asset-manager.php`** — Wrapped 2 occurrences of `wppo_page_assets_` keys.
- **`includes/class-rest.php`** — Wrapped dynamic `wppo_audit_` key construction.
- **`uninstall.php`** — Added inline blog-ID prefixing for transient cleanup during site iteration.
- **`AGENTS.md`** — Documented multisite compatibility approach.

## Files Changed

- `AGENTS.md`
- `includes/class-activate.php`
- `includes/class-admin-notices.php`
- `includes/class-asset-manager.php`
- `includes/class-cache.php`
- `includes/class-critical-css.php`
- `includes/class-cron.php`
- `includes/class-database-cleanup.php`
- `includes/class-main.php`
- `includes/class-pagespeed.php`
- `includes/class-rest.php`
- `includes/class-telemetry.php`
- `includes/class-util.php`
- `uninstall.php`
- `vendor/composer/installed.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-437`.*