### PR TITLE
[Autofix] [WP Monitor] Keep drop-in wp_cache_supports() feature list in sync with core

### DIFF
--- a/templates/object-cache.php
+++ b/templates/object-cache.php
@@ -1045,11 +1045,25 @@ if ( ! function_exists( 'wp_cache_supports' ) ) {
 	 * @return bool True if the feature is supported, false otherwise.
 	 */
 	function wp_cache_supports( $feature ) {
+		/*
+		 * Keep this list in sync with core's wp_cache_supports() in wp-includes/cache.php.
+		 * Re-diff the claim list against core each release and claim a new feature only
+		 * when the drop-in actually implements it. The compatible feature list here is
+		 * core's authoritative list (add_multiple, set_multiple, get_multiple,
+		 * delete_multiple, flush_runtime, flush_group) minus flush_runtime:
+		 *
+		 *  - add_multiple is served by core's cache-compat.php fallback, which loops
+		 *    wp_cache_add() per key, so it is genuinely supported.
+		 *  - flush_runtime is intentionally NOT claimed: this drop-in has no runtime-only
+		 *    flush, so core's compat wp_cache_flush_runtime() would delegate to a full
+		 *    persistent Redis flush, which is not what a runtime-only caller expects.
+		 */
 		switch ( $feature ) {
-			case 'flush_group':
-			case 'get_multiple':
+			case 'add_multiple':
 			case 'set_multiple':
+			case 'get_multiple':
 			case 'delete_multiple':
+			case 'flush_group':
 				return true;
 			default:
 				return false;

--- a/tests/php/ObjectCacheTest.php
+++ b/tests/php/ObjectCacheTest.php
@@ -274,6 +274,39 @@ class ObjectCacheTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Test that wp_cache_supports() claims every feature the drop-in implements.
+	 *
+	 * The list mirrors core's wp_cache_supports() minus flush_runtime. add_multiple is
+	 * served by core's cache-compat.php fallback (loops wp_cache_add() per key), so it is
+	 * genuinely supported by this drop-in.
+	 */
+	public function test_wp_cache_supports_claims_implemented_features(): void {
+		$this->assertTrue( wp_cache_supports( 'add_multiple' ) );
+		$this->assertTrue( wp_cache_supports( 'set_multiple' ) );
+		$this->assertTrue( wp_cache_supports( 'get_multiple' ) );
+		$this->assertTrue( wp_cache_supports( 'delete_multiple' ) );
+		$this->assertTrue( wp_cache_supports( 'flush_group' ) );
+	}
+
+	/**
+	 * Test that wp_cache_supports() does NOT claim flush_runtime.
+	 *
+	 * The drop-in has no runtime-only flush, so claiming it would make core's compat
+	 * wp_cache_flush_runtime() delegate to a full persistent Redis flush instead of a
+	 * cheap in-memory-only invalidation.
+	 */
+	public function test_wp_cache_supports_does_not_claim_flush_runtime(): void {
+		$this->assertFalse( wp_cache_supports( 'flush_runtime' ) );
+	}
+
+	/**
+	 * Test that wp_cache_supports() returns false for unknown features.
+	 */
+	public function test_wp_cache_supports_returns_false_for_unknown_features(): void {
+		$this->assertFalse( wp_cache_supports( 'not_a_real_feature' ) );
+	}
+
+	/**
 	 * Test that a differently ordered array salt produces a different normalized salt.
 	 */
 	public function test_array_salt_order_changes_normalized_salt(): void {


### PR DESCRIPTION
## Fixes #531

## What Was Changed

# Fix Summary — Issue #531: Keep drop-in `wp_cache_supports()` feature list in sync with core

## What Was Done

Updated the Redis drop-in's hand-rolled `wp_cache_supports()` in `templates/object-cache.php` to mirror WordPress core's authoritative feature list, adding `add_multiple` (previously missing) while deliberately keeping `flush_runtime` unclaimed. Added PHPUnit coverage for the capability-reporting function.

## Approach

Core's `wp_cache_supports()` (WP 6.1+, authoritative list in `wp-includes/cache.php`) documents six features: `add_multiple`, `set_multiple`, `get_multiple`, `delete_multiple`, `flush_runtime`, `flush_group`. The drop-in claimed only four.

- **`add_multiple` added**: `wp_cache_add_multiple()` is always provided at runtime by core's `cache-compat.php` (loaded unconditionally alongside the drop-in), which loops `wp_cache_add()` per key — a genuine, functional implementation with this drop-in, so the feature is legitimately supported.
- **`flush_runtime` intentionally NOT claimed**: the drop-in has no runtime-only flush (the class only exposes `flush()` and `flush_group()`). Core's compat `wp_cache_flush_runtime()` checks `wp_cache_supports('flush_runtime')` first; claiming it would turn a cheap "in-memory only" invalidation into a full persistent Redis wipe, which is not what a runtime-only caller expects.
- A maintenance docblock above the `switch` encodes the re-diff process from the issue so the list stays in sync with core each release, and documents why `flush_runtime` is excluded.

This is Option A from the implementation plan (static claim list, matching the existing un-guarded style of the other claims; the `function_exists()` guard is unnecessary because `cache-compat.php` guarantees `wp_cache_add_multiple()` exists on WP 6.2+). The object cache implementation itself is unchanged; only the capability-reporting function was touched.

**Test discovery fix**: the test file `tests/php/class-object-cache-test.php` did not match PHPUnit's required `*Test.php` discovery suffix (documented in AGENTS.md), so the entire existing suite — including the WP 6.9 salted-cache tests added in #512 — was silently never executed. It was renamed to `tests/php/ObjectCacheTest.php` so the new `wp_cache_supports()` coverage (and the pre-existing tests) actually run.

## Key Changes

- **`templates/object-cache.php`** — `wp_cache_supports()` now claims `add_multiple`, `set_multiple`, `get_multiple`, `delete_multiple`, `flush_group` (core order minus `flush_runtime`), with a maintenance comment documenting the per-release re-diff process and the `flush_runtime` exclusion rationale.
- **`tests/php/ObjectCacheTest.php`** (renamed from `class-object-cache-test.php`) — added three tests: `wp_cache_supports()` returns `true` for all five implemented features, returns `false` for `flush_runtime` (with rationale), and returns `false` for unknown features.

## Verification

- `npm run lint:js` — pass
- `composer lint` — pass
- `npm test` (Jest) — 233/233 pass
- `composer test` (PHPUnit) — new `ObjectCacheTest` suite: 13/13 pass (10 existing + 3 new). Pre-existing unrelated failures remain in `CacheTest` (missing `should_inline_combined_css()` method) and are present on the clean baseline.
- `npm run build` — pass, no build artifacts changed

## Files Changed

- `templates/object-cache.php`
- `tests/php/ObjectCacheTest.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-531`.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache capability reporting to accurately include bulk cache operations and group flushing.
  * Confirmed unsupported runtime flushing and unknown capabilities are correctly rejected.

* **Documentation**
  * Clarified compatibility with WordPress core cache-support behavior.

* **Tests**
  * Added coverage for supported and unsupported cache capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->