### PR TITLE
⚡ Bolt: [Performance improvement] Centralize content_url caching into Util::cached_content_url

### DIFF
--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -904,20 +904,17 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 				if ( empty( $local_path ) ) {
 					// If Util::get_local_path failed, manually resolve if it's a URL.
 					static $home_url    = array();
-					static $content_url = array();
+					$content_url_base   = untrailingslashit( Util::cached_content_url( '' ) );
 					$blog_id            = get_current_blog_id();
 
 					if ( ! isset( $home_url[ $blog_id ] ) ) {
 						$home_url[ $blog_id ] = untrailingslashit( home_url() );
 					}
-					if ( ! isset( $content_url[ $blog_id ] ) ) {
-						$content_url[ $blog_id ] = untrailingslashit( content_url() );
-					}
 
 					$local_base = wp_normalize_path( ABSPATH );
 
-					if ( strpos( $source_image, $content_url[ $blog_id ] ) === 0 ) {
-						$relative_path = substr( $source_image, strlen( $content_url[ $blog_id ] ) );
+					if ( strpos( $source_image, $content_url_base ) === 0 ) {
+						$relative_path = substr( $source_image, strlen( $content_url_base ) );
 						$local_base    = wp_normalize_path( WP_CONTENT_DIR );
 					} elseif ( strpos( $source_image, $home_url[ $blog_id ] ) === 0 ) {
 						$relative_path = substr( $source_image, strlen( $home_url[ $blog_id ] ) );

--- a/includes/class-img-converter.php
+++ b/includes/class-img-converter.php
@@ -903,9 +903,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Img_Converter' ) ) {
 
 				if ( empty( $local_path ) ) {
 					// If Util::get_local_path failed, manually resolve if it's a URL.
-					static $home_url    = array();
-					$content_url_base   = untrailingslashit( Util::cached_content_url( '' ) );
-					$blog_id            = get_current_blog_id();
+					static $home_url  = array();
+					$content_url_base = untrailingslashit( Util::cached_content_url( '' ) );
+					$blog_id          = get_current_blog_id();
 
 					if ( ! isset( $home_url[ $blog_id ] ) ) {
 						$home_url[ $blog_id ] = untrailingslashit( home_url() );

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -2151,17 +2151,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 
 			if ( $cached_file ) {
 				$basename = basename( $cached_file );
-				if ( false !== has_filter( 'content_url' ) ) {
-					$content_url = content_url( 'cache/wppo/min/css/' . $basename );
-				} else {
-					static $content_url_base = array();
-					$blog_id                 = get_current_blog_id();
-
-					if ( ! isset( $content_url_base[ $blog_id ] ) ) {
-						$content_url_base[ $blog_id ] = content_url( 'cache/wppo/min/css/' );
-					}
-					$content_url = $content_url_base[ $blog_id ] . $basename;
-				}
+				$content_url = Util::cached_content_url( 'cache/wppo/min/css/' . $basename );
 
 				$file_version = filemtime( Util::get_local_path( $cached_file ) );
 				$new_href     = $content_url . '?ver=' . $file_version;
@@ -2212,17 +2202,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 
 			if ( $cached_file ) {
 				$basename = basename( $cached_file );
-				if ( false !== has_filter( 'content_url' ) ) {
-					$content_url = content_url( 'cache/wppo/min/js/' . $basename );
-				} else {
-					static $content_url_base = array();
-					$blog_id                 = get_current_blog_id();
-
-					if ( ! isset( $content_url_base[ $blog_id ] ) ) {
-						$content_url_base[ $blog_id ] = content_url( 'cache/wppo/min/js/' );
-					}
-					$content_url = $content_url_base[ $blog_id ] . $basename;
-				}
+				$content_url = Util::cached_content_url( 'cache/wppo/min/js/' . $basename );
 
 				$file_version = filemtime( Util::get_local_path( $cached_file ) );
 

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -2150,7 +2150,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 			$cached_file  = $css_minifier->minify();
 
 			if ( $cached_file ) {
-				$basename = basename( $cached_file );
+				$basename    = basename( $cached_file );
 				$content_url = Util::cached_content_url( 'cache/wppo/min/css/' . $basename );
 
 				$file_version = filemtime( Util::get_local_path( $cached_file ) );
@@ -2201,7 +2201,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 			$cached_file = $js_minifier->minify();
 
 			if ( $cached_file ) {
-				$basename = basename( $cached_file );
+				$basename    = basename( $cached_file );
 				$content_url = Util::cached_content_url( 'cache/wppo/min/js/' . $basename );
 
 				$file_version = filemtime( Util::get_local_path( $cached_file ) );

--- a/includes/class-used-css.php
+++ b/includes/class-used-css.php
@@ -1126,7 +1126,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Used_CSS' ) ) {
 					if ( ! empty( $local_path ) ) {
 						$min_file = wp_normalize_path( WP_CONTENT_DIR . '/cache/wppo/min/css/' . basename( $local_path ) );
 						if ( file_exists( $min_file ) ) {
-							$removal_urls[ content_url( 'cache/wppo/min/css/' . basename( $min_file ) ) ] = true;
+							$removal_urls[ Util::cached_content_url( 'cache/wppo/min/css/' . basename( $min_file ) ) ] = true;
 						}
 					}
 				}


### PR DESCRIPTION
💡 What:
Replaces duplicated static array caching of `content_url` across `class-main.php`, `class-img-converter.php`, and `class-used-css.php` with a centralized `Util::cached_content_url()` utility method.

🎯 Why:
The blog-ID-keyed static cache arrays were previously duplicated in multiple minification and URL processing loops. Moving this logic to a single helper method removes duplicate code and ensures consistency with the existing base-URL caching pattern used in `class-main.php`, slightly improving memory usage and reducing redundancy when these operations occur.

📊 Impact:
Slight improvement in code maintainability and memory footprint by replacing inline static cache arrays initialized across multiple loops and callbacks with a central cached utility.

🔬 Measurement:
Run unit tests and `php -l` on the files changed to verify no regressions. Observe that caching features reliant on these URLs (minification, background image processing) remain functional when `wppo_settings` is enabled.

---
*PR created automatically by Jules for task [1076249866565627080](https://jules.google.com/task/1076249866565627080) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cached image, CSS, and JavaScript asset URLs.
  * Enhanced compatibility for cached assets across multisite setups.
  * Preserved existing file path conversion and safety checks for image handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->