### PR TITLE
[Autofix] 4. AGENTS.md has stale/inconsistent REST endpoint counts

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -34,7 +34,7 @@ npm run build           # wp-scripts build
 | `.distignore` | WordPress.org SVN exclusion rules |
 | `scripts/build-release.sh` | Builds release ZIP |
 | `includes/class-main.php` | Main orchestrator class |
-| `includes/class-rest.php` | 16 REST API endpoints |
+| `includes/class-rest.php` | 21 REST API endpoints |
 
 ## Vendor Directory
 

--- a/.audit-prompts/security.md
+++ b/.audit-prompts/security.md
@@ -26,7 +26,7 @@ You are auditing a WordPress performance plugin for security vulnerabilities. Fo
 - PageSpeed API key not exposed in JS globals accessible to non-admins
 
 ### REST API Security
-- All 16 REST endpoints require `manage_options` + nonce — verify none are missing
+- All 21 REST endpoints require `manage_options` + nonce — verify none are missing
 - Rate limiting or throttle protection for resource-intensive endpoints (image conversion, PageSpeed scan)
 - No unauthenticated endpoints that trigger heavy background jobs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Frontend lazy loading: `src/lazyload.js` (vanilla JS, not React) — Intersectio
 Admin bar cache clearing: `src/main.js` — two buttons ("Clear All Cache", "Clear This Page") with automatic nonce refresh on 403.
 
 ### REST API
-Namespace `performance-optimisation/v1`, defined in `includes/class-rest.php` (20 endpoints). All require `manage_options` capability + `X-WP-Nonce`.
+Namespace `performance-optimisation/v1`, defined in `includes/class-rest.php` (21 endpoints). All require `manage_options` capability + `X-WP-Nonce`.
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
@@ -115,7 +115,7 @@ Namespace `performance-optimisation/v1`, defined in `includes/class-rest.php` (2
 | `class-cron.php` | WP-Cron: preload (5h), image conversion (hourly), DB cleanup (daily) |
 | `class-img-converter.php` | WebP/AVIF conversion (GD, Imagick), deferred option commits |
 | `class-image-optimisation.php` | Next-gen serving, lazy load, picture wrap, preload, video lazy |
-| `class-rest.php` | All 16 REST API endpoints |
+| `class-rest.php` | All 21 REST API endpoints |
 | `class-pagespeed.php` | Google PageSpeed Insights API + Action Scheduler job |
 | `class-suggestion-engine.php` | Performance suggestions from telemetry + PageSpeed |
 | `class-telemetry.php` | Local cURL-based performance scanner |

--- a/tests/php/RestTest.php
+++ b/tests/php/RestTest.php
@@ -115,6 +115,8 @@ class RestTest extends \PHPUnit\Framework\TestCase {
 			'import_settings',
 			'database_cleanup',
 			'database_cleanup_counts',
+			'get_page_assets',
+			'image_job_status',
 			'object_cache',
 			'system_info',
 			'performance_scan',
@@ -127,6 +129,9 @@ class RestTest extends \PHPUnit\Framework\TestCase {
 			'ccss_status',
 			'dismiss_welcome',
 		);
+
+		// Keep in sync with AGENTS.md endpoint count (21).
+		$this->assertCount( 21, $routes );
 
 		foreach ( $expected as $route ) {
 			$this->assertArrayHasKey( $route, $routes, "Missing route: {$route}" );


### PR DESCRIPTION
## Fixes #550

## What Was Changed

# Fix Summary: AGENTS.md stale/inconsistent REST endpoint counts

## What Was Done
Updated all stale REST endpoint counts (20/16) in the agent-facing documentation to the real value (21) and hardened the REST route unit test so CI fails if the documented count ever drifts from `get_routes()` again.

## Approach
Counted the routes registered in `includes/class-rest.php::get_routes()` (verified 21, including `get_page_assets`, `image_job_status`, and `dismiss_welcome`), then corrected every reference that named a wrong number. Since `wppo-ai-review` / `daily-audit` workflows treat `AGENTS.md` as ground truth, all four stale references were fixed, not just the two explicitly called out in the issue (Option A from the implementation plan). Added an exact-count assertion plus the two previously-missing route names to `RestTest` so any future route addition/removal triggers a deliberate documentation update instead of silently passing an incomplete test.

## Key Changes
- `AGENTS.md:78` — "20 endpoints" → "21 endpoints" (REST API section).
- `AGENTS.md:118` — "All 16 REST API endpoints" → "All 21 REST API endpoints" (class table).
- `.agents/AGENTS.md:37` — "16 REST API endpoints" → "21 REST API endpoints" (agent workspace ground truth).
- `.audit-prompts/security.md:29` — "All 16 REST endpoints require" → "All 21 REST endpoints require" (security audit checklist).
- `tests/php/RestTest.php` — Added `get_page_assets` and `image_job_status` to the expected routes array (they were registered but omitted from the test), plus `assertCount( 21, $routes )` with a comment to keep in sync with the documented endpoint count. RestTest: 7 tests, 70 assertions passing.

## Verification
All required checks pass in order:
- `npm run lint:js` — pass (1 pre-existing warning in `src/components/ObjectCache.js`, 0 errors)
- `composer lint` — pass
- `npm test` — pass (23 suites, 255 tests)
- `npm run build` — pass (webpack compiled successfully)

Note: the full `composer test` suite aborts partway through with a Brain Monkey `wp_parse_url()` redeclaration fatal error. This reproduces identically on the unmodified base commit (verified via `git stash`), so it is a pre-existing environment/CI issue unrelated to this change; `tests/php/RestTest.php` passes in isolation.

## Files Changed

- `.agents/AGENTS.md`
- `.audit-prompts/security.md`
- `AGENTS.md`
- `tests/php/RestTest.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-550`.*