### PR TITLE
[Autofix] 5. Consolidate scattered "remove when minimum WP is raised" TODOs

### DIFF
--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -723,7 +723,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 		 * @since 1.0.0
 		 */
 		public function start_output_buffer(): void {
-			// TODO: remove when minimum supported WP is raised to 6.9.
+			// TODO(#553): remove when minimum supported WP is raised to 6.9.
 			if ( ! $this->is_cache_allowed_for_current_user() || $this->is_not_cacheable() ) {
 				return;
 			}

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -373,11 +373,11 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 			// The native 'strategy' script data added via wp_script_add_data() is only
 			// honoured by core since WP 6.3, so the native defer path is gated to 6.3+
 			// and older core (WP 6.2) uses the legacy script_loader_tag fallback.
-			// TODO: remove the legacy fallback when minimum supported WP is raised to 6.3.
+			// TODO(#553): remove the legacy fallback when minimum supported WP is raised to 6.3.
 			$is_wp63_plus = version_compare( $wp_version, '6.3-alpha', '>=' );
 			// Pre-release-inclusive floor: '6.9-alpha' also matches alpha/beta/RC builds
 			// of 6.9 which already ship the template-enhancement buffer functions.
-			// TODO: remove the legacy buffer paths when minimum supported WP is raised to 6.9.
+			// TODO(#553): remove the legacy buffer paths when minimum supported WP is raised to 6.9.
 			$is_wp69_plus = version_compare( $wp_version, '6.9-alpha', '>=' );
 
 			// Delay JS: the script_loader_tag filter performs the wppo-src/type rewriting
@@ -417,7 +417,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 					add_action( 'wp_finalized_template_enhancement_output_buffer', array( $this->cache, 'stash_cache' ) );
 				} else {
 					// Legacy path (deprecated) — earmarked for removal when WP 6.9+ becomes the minimum supported version.
-					// TODO: remove when minimum supported WP is raised to 6.9.
+					// TODO(#553): remove when minimum supported WP is raised to 6.9.
 					add_action( 'template_redirect', array( $this->cache, 'start_output_buffer' ) );
 				}
 				add_action( 'save_post', array( $this, 'on_save_post_invalidate_cache' ), 10, 3 );
@@ -439,7 +439,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 					add_filter( 'wp_template_enhancement_output_buffer', array( $this, 'process_used_css_only' ), 20, 2 );
 				} else {
 					// Legacy path (deprecated) — earmarked for removal when WP 6.9+ becomes the minimum supported version.
-					// TODO: remove when minimum supported WP is raised to 6.9.
+					// TODO(#553): remove when minimum supported WP is raised to 6.9.
 					add_action( 'template_redirect', array( $this, 'start_used_css_buffer' ) );
 				}
 			}
@@ -453,6 +453,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 					// Legacy path: priority 20 runs AFTER the cache buffer (default priority 10),
 					// so its inner callback runs first on the raw buffer and the cache callback
 					// then stores the LCP-enhanced HTML — mirroring the 6.9+ flow.
+					// TODO(#553): remove the legacy LCP buffer path when minimum supported WP is raised to 6.9.
 					add_action( 'template_redirect', array( $this, 'start_lcp_priority_buffer' ), 20 );
 				}
 			}


### PR DESCRIPTION
## Fixes #553

## What Was Changed

## Fix Summary: Consolidate scattered "remove when minimum WP is raised" TODOs (#553)

### What Was Done
Linked the five free-text `// TODO:` comments that reference future WordPress version
floors (6.3 and 6.9) to the consolidated tracking issue #553, so they do not silently rot as
the plugin's `Requires at least` header rises over time. Per the maintainer's decision
(Option A), issue #553 itself is reused as the single tracking issue.

### Approach

These are comment-only changes with no runtime impact. Each legacy-fallback TODO comment now
carries a machine-readable `// TODO(#553):` reference pointing to the tracking issue titled
"Raise minimum supported WordPress version to 6.9, remove legacy fallbacks." Issue #553 is
already labeled `tracking`, making it the canonical owner of the future-removal work. No logic
checks, tests, or build output were touched; a sibling LCP-priority legacy branch got a matching
consistency comment.

### Key Changes

- `includes/class-main.php:376` — replaced `// TODO:` with `// TODO(#553): remove the legacy fallback when minimum supported WP is raised to 6.3.`
- `includes/class-main.php:380` — replaced `// TODO:` with `// TODO(#553): remove the legacy buffer paths when minimum supported WP is raised to 6.9.`
- `includes/class-main.php:420` — replaced `// TODO:` with `// TODO(#553): remove when minimum supported WP is raised to 6.9.`
- `includes/class-main.php:442` — replaced `// TODO:` with `// TODO(#553): remove when minimum supported WP is raised to 6.9.`
- `includes/class-main.php:456` — added `// TODO(#553): remove the legacy LCP buffer path when minimum supported WP is raised to 6.9.` for consistency with the sibling legacy branches.
- `includes/class-cache.php:726` — replaced `// TODO:` with `// TODO(#553): remove when minimum supported WP is raised to 6.9.`

All six `TODO(#553)` references were verified via grep. Verification (per AGENTS.md order):
1. `npm run lint:js` — 0 errors (1 pre-existing react-hooks warning)
2. `composer lint` — exit 0, no PHPCS violations
3. `npm test` — 23 suites / 255 tests passed
4. `npm run build` — compiled successfully, no tracked build artifacts changed

## Files Changed

- `includes/class-cache.php`
- `includes/class-main.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-553`.*