### PR TITLE
[Autofix] Clean up orphaned options during uninstall in uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -36,6 +36,16 @@ if ( ! function_exists( 'wppo_cleanup_site' ) ) {
 		delete_option( 'wppo_last_db_cleanup' );
 		delete_option( 'wppo_version' );
 		delete_option( 'wppo_block_assets_migrated' );
+		delete_option( 'wppo_cache_last_cleared' );
+		delete_option( 'wppo_cache_last_cleared_time' );
+		delete_option( 'wppo_activation_time' );
+		delete_option( 'wppo_activity_cache_version' );
+		delete_option( 'wppo_audit_salt' );
+		delete_option( 'wppo_db_cleanup_salt' );
+		delete_option( 'wppo_activity_log_salt' );
+		delete_option( 'wppo_img_info_salt' );
+		delete_option( 'wppo_review_dismissed' );
+		delete_option( 'wppo_review_snoozed_until' );
 
 		// Delete post meta using the meta API to respect hooks.
 		delete_post_meta_by_key( '_wppo_preload_image_url' );


### PR DESCRIPTION
## Fixes #558

## What Was Changed

### What Was Done

Added `delete_option()` calls in `uninstall.php` for 10 runtime-written options that were previously left behind after plugin uninstallation. This closes issue #558 by ensuring full cleanup of orphaned `wppo_*` options from `wp_options`.

### Approach

`wppo_cleanup_site()` in `uninstall.php` already deleted the plugin's core options (`wppo_settings`, `wppo_img_info`, etc.), but a static list meant several options written at runtime by other classes were never removed. Per the maintainer's decision (Option B), the 7 options listed in the issue plus 3 additional orphaned options discovered during analysis are now deleted.

Deleting non-existent options is a no-op in WordPress (`delete_option()` returns `false` silently), so there is no functional risk — the change is purely additive data hygiene. Since `uninstall.php` runs per-site on both single and multisite installs via `wppo_cleanup_site()`, the added calls cover every site in a network.

### Key Changes

- **`uninstall.php`** — Added 10 `delete_option()` calls to the "Delete options" block of `wppo_cleanup_site()`:
  - From the issue: `wppo_cache_last_cleared`, `wppo_cache_last_cleared_time`, `wppo_activation_time`, `wppo_activity_cache_version`, `wppo_audit_salt`, `wppo_db_cleanup_salt`, `wppo_activity_log_salt`
  - Additional orphans (Option B): `wppo_img_info_salt`, `wppo_review_dismissed`, `wppo_review_snoozed_until`

### Verification

All four required checks pass:
- `npm run lint:js` — 0 errors (1 pre-existing unrelated warning in `ObjectCache.js`)
- `composer lint` — clean
- `npm test` — 23 suites / 255 tests pass
- `npm run build` — compiled successfully

## Files Changed

- `uninstall.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-558`.*