### PR TITLE
[Autofix] Add shared file locking with flock() in Main::is_file_minified()

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -2257,6 +2257,14 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				return true;
 			}
 
+			// Acquire a shared read lock to avoid reading a partially-written file.
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+			if ( ! flock( $handle, LOCK_SH ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+				fclose( $handle );
+				return true;
+			}
+
 			$line_count  = 0;
 			$total_chars = 0;
 			$max_lines   = 50;
@@ -2271,6 +2279,8 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fgets
 				$line = fgets( $handle );
 			}
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_flock
+			flock( $handle, LOCK_UN );
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 			fclose( $handle );
 


### PR DESCRIPTION
## Fixes #560

## What Was Changed

# Add shared file locking with flock() in is_file_minified()

### What Was Done
Added a shared read lock (`flock( LOCK_SH )`) around the file read in `is_file_minified()` in `includes/class-main.php` to prevent reading partially written CSS/JS files during concurrent writes. The lock is released (`flock( LOCK_UN )`) before the file handle is closed.

### Approach
The function opens the target file with `fopen( $file_path, 'r' )` and reads up to 50 lines via `fgets()` to guess whether the content is minified. Without a lock, a concurrent writer holding `LOCK_EX` could leave the handle mid-write, yielding torn/partial lines and a wrong minified/unminified determination. That result is then cached for 1 hour via `wp_cache_set()`, so a momentary race would echo for an hour.

The fix acquires an advisory shared read lock immediately after the successful `fopen()`. Since the file is opened read-only, `LOCK_SH` is correct and safely blocks until any exclusive-write process releases its lock. If the lock cannot be acquired, the handle is closed and the function safely falls back to its existing "assume minified" path (`return true`). The lock is released with `LOCK_UN` before `fclose()`, matching the existing WPCS inline-suppression style.

No changes were needed to `is_css_minified()` / `is_js_minified()`, which simply delegate to this method.

### Key Changes
- `includes/class-main.php` — Added `flock( $handle, LOCK_SH )` after the `fopen()` guard in `is_file_minified()`, with `phpcs:ignore` suppressions and a defensive `return true` fallback when locking fails; added `flock( $handle, LOCK_UN )` before the existing `fclose()`.

### Verification
All four required checks passed:
- `npm run lint:js` — no errors (pre-existing warning only)
- `composer lint` — no PHPCS violations
- `npm test` — 255 tests passed across 23 suites
- `npm run build` — compiled successfully

## Files Changed

- `includes/class-main.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-560`.*