### PR TITLE
[Autofix] Prevent delayJS from overriding deferred script handles in Main::setup_hooks()

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -527,6 +527,16 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				} else {
 					$this->exclude_delay_js = $exclude_js;
 				}
+
+				// When both defer JS and delay JS are active, deferred handles must not
+				// be delay-rewritten (wppo-src / wppo/javascript) — otherwise delay JS
+				// overrides the native defer strategy on WP 6.3+ and corrupts script
+				// attributes. Merge the defer exclusions so add_defer_attribute() and
+				// apply_per_page_delay_config() skip deferred scripts entirely.
+				if ( ! empty( $this->options['file_optimisation']['deferJS'] ) ) {
+					$this->exclude_delay_js = array_merge( $this->exclude_delay_js, $this->exclude_defer_js );
+				}
+
 				$this->exclude_delay_js = apply_filters( 'wppo_exclude_delay_js', $this->exclude_delay_js );
 
 				// Parse delay strategy lists.

--- a/tests/php/MainDelayDeferTest.php
+++ b/tests/php/MainDelayDeferTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Tests for Main defer/delay JS exclusion reconciliation.
+ *
+ * Verifies that when both Defer JS and Delay JS are active, the deferred script
+ * handles are merged into the delay-JS exclusion list so delay processing never
+ * rewrites (wppo-src / wppo/javascript) scripts that are deferred natively.
+ *
+ * @package PerformanceOptimise\Tests
+ */
+
+use PerformanceOptimise\Inc\Main;
+use Brain\Monkey\Functions;
+
+/**
+ * Tests the setup_hooks() defer/delay exclusion merge.
+ *
+ * @package PerformanceOptimise\Tests
+ */
+class MainDelayDeferTest extends \PHPUnit\Framework\TestCase {
+	use WPPO_Test_Bootstrap;
+
+	/**
+	 * Stub the WP environment needed to construct Main with the given
+	 * file_optimisation overrides.
+	 *
+	 * @param array $file_overrides file_optimisation option overrides.
+	 * @return void
+	 */
+	private function stub_main_construction( array $file_overrides ): void {
+		Functions\stubs(
+			array(
+				'WP_Filesystem'       => false,
+				'sanitize_text_field' => '',
+				'wp_unslash'          => '',
+				'is_user_logged_in'   => false,
+				'absint'              => 3000,
+			)
+		);
+
+		Functions\when( 'get_option' )->alias(
+			static function ( $option, $default_value = false ) use ( $file_overrides ) {
+				if ( 'wppo_settings' === $option && is_array( $default_value ) ) {
+					$default_value['file_optimisation'] = array_merge( $default_value['file_optimisation'] ?? array(), $file_overrides );
+				}
+				return $default_value;
+			}
+		);
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\when( 'wp_normalize_path' )->returnArg();
+		Functions\when( 'content_url' )->returnArg();
+		Functions\when( 'trailingslashit' )->returnArg();
+		Functions\when( 'wp_is_block_theme' )->justReturn( false );
+		Functions\when( 'get_bloginfo' )->justReturn( '6.8' );
+
+		// Only the target function_exists probes are faked; everything else is
+		// delegated to the real function_exists so the rest of the Main
+		// constructor keeps running on its real branch.
+		Functions\when( 'function_exists' )->alias(
+			static function ( $function_name ) {
+				if ( 'WP_Filesystem' === $function_name || 'wp_is_block_theme' === $function_name ) {
+					return true;
+				}
+				return \function_exists( $function_name );
+			}
+		);
+	}
+
+	/**
+	 * Read a private property off a Main instance.
+	 *
+	 * @param Main   $main Main instance.
+	 * @param string $prop Property name.
+	 * @return mixed Property value.
+	 */
+	private function read_private_prop( Main $main, string $prop ) {
+		$reflection = new \ReflectionProperty( Main::class, $prop );
+		$reflection->setAccessible( true );
+		return $reflection->getValue( $main );
+	}
+
+	/**
+	 * Test that deferred handles (default + user-configured) are merged into the
+	 * delay-JS exclusion list when both defer and delay JS are active.
+	 */
+	public function test_deferred_handles_merged_into_delay_exclusions_when_both_enabled(): void {
+		$this->stub_main_construction(
+			array(
+				'deferJS'        => true,
+				'delayJS'        => true,
+				'excludeDeferJS' => "my-deferred-script\nhttps://cdn.example.com/analytics.js",
+				'excludeDelayJS' => 'my-delay-only-script',
+			)
+		);
+
+		$main = new Main();
+
+		$delay_excludes = $this->read_private_prop( $main, 'exclude_delay_js' );
+
+		$this->assertContains( 'wppo-lazyload', $delay_excludes );
+		$this->assertContains( 'my-deferred-script', $delay_excludes );
+		$this->assertContains( 'https://cdn.example.com/analytics.js', $delay_excludes );
+		$this->assertContains( 'my-delay-only-script', $delay_excludes );
+	}
+
+	/**
+	 * Test that deferred handles are NOT merged into the delay-JS exclusion list
+	 * when defer JS is disabled.
+	 */
+	public function test_deferred_handles_not_merged_when_defer_disabled(): void {
+		$this->stub_main_construction(
+			array(
+				'deferJS'        => false,
+				'delayJS'        => true,
+				'excludeDeferJS' => 'my-deferred-script',
+			)
+		);
+
+		$main = new Main();
+
+		$delay_excludes = $this->read_private_prop( $main, 'exclude_delay_js' );
+
+		$this->assertContains( 'wppo-lazyload', $delay_excludes );
+		$this->assertNotContains( 'my-deferred-script', $delay_excludes );
+	}
+
+	/**
+	 * Test that handles added through the wppo_exclude_defer_js filter are also
+	 * merged into the delay-JS exclusion list when both options are active.
+	 */
+	public function test_wppo_exclude_defer_js_filter_handles_merged_into_delay_exclusions(): void {
+		$this->stub_main_construction(
+			array(
+				'deferJS' => true,
+				'delayJS' => true,
+			)
+		);
+
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $hook, $value ) {
+				if ( 'wppo_exclude_defer_js' === $hook && is_array( $value ) ) {
+					$value[] = 'filter-added-defer-handle';
+				}
+				return $value;
+			}
+		);
+
+		$main = new Main();
+
+		$delay_excludes = $this->read_private_prop( $main, 'exclude_delay_js' );
+
+		$this->assertContains( 'filter-added-defer-handle', $delay_excludes );
+	}
+
+	/**
+	 * Test that add_defer_attribute() leaves a deferred handle's tag untouched
+	 * when both defer and delay JS are active.
+	 */
+	public function test_add_defer_attribute_skips_deferred_handle_when_both_enabled(): void {
+		$this->stub_main_construction(
+			array(
+				'deferJS'        => true,
+				'delayJS'        => true,
+				'excludeDeferJS' => 'my-deferred-script',
+			)
+		);
+
+		$main = new Main();
+
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript -- Static fixture HTML for add_defer_attribute() tests.
+		$tag    = '<script src="https://example.com/my-deferred-script.js" type="text/javascript"></script>';
+		$result = $main->add_defer_attribute( $tag, 'my-deferred-script' );
+
+		$this->assertSame( $tag, $result );
+	}
+}


### PR DESCRIPTION
## Fixes #562

## What Was Changed

# Fix Summary: Prevent delayJS from overriding deferred script handles (#562)

## What Was Done
Fixed a conflict in `Main::setup_hooks()` where, when both **Defer JS** and **Delay JS** were enabled, the delay-JS `script_loader_tag` filter (`add_defer_attribute()`) rewrote deferred script handles (`src` → `wppo-src`, `type` → `wppo/javascript`), overriding the native defer strategy on WP 6.3+ and corrupting the script attributes. Deferred handles are now merged into the delay-JS exclusion list so delay processing never touches them.

## Approach
`$this->exclude_defer_js` is populated by the defer block of `setup_hooks()` *before* the delay block runs. Inside the delay block, after the user `excludeDelayJS` exclusions are resolved and before the `wppo_exclude_delay_js` filter is applied, we merge the defer exclusions into `$this->exclude_delay_js` whenever `deferJS` is enabled. This single, gated merge means:

- `add_defer_attribute()` (class-main.php:1598) skips deferred handles entirely, so they keep their native `defer`/`strategy` attributes.
- `apply_per_page_delay_config()` (class-main.php:1740) skips per-page delay strategy overrides for deferred handles.
- The legacy `< 6.3` defer path (`add_defer_attribute_legacy()`) receives the untouched `src` tag it expects.
- Duplicates from `array_merge()` are harmless for the strict `in_array()` lookups used.

This matches the issue's suggested fix and the existing `wppo-lazyload` default-exclusion convention (merge before the `wppo_exclude_delay_js` filter).

## Key Changes
- **`includes/class-main.php`** — Added the defer→delay exclusion merge inside the `delayJS` block of `setup_hooks()`, gated on `deferJS` being active. When only one of the two features is enabled the behavior is unchanged.
- **`tests/php/MainDelayDeferTest.php`** — New Brain Monkey unit test (mirroring `MainBlockAssetsTest` construction stubbing, plus the `get_bloginfo`/`absint` stubs the Main constructor needs) covering:
  - Deferred handles (default + user-configured `excludeDeferJS`) are present in `exclude_delay_js` when both options are on.
  - Deferred handles are **not** merged when `deferJS` is off.
  - Handles added via the `wppo_exclude_defer_js` filter are merged too.
  - `add_defer_attribute()` returns a deferred handle's tag unchanged when both options are on.

## Verification
- `npm run lint:js` — passed (1 pre-existing warning in `src/components/ObjectCache.js`, 0 errors).
- `composer lint` — passed.
- `npm test` — 23 suites / 255 tests passed.
- `npm run build` — compiled successfully; no JS/build output changed.
- New suite: `vendor/bin/phpunit tests/php/MainDelayDeferTest.php` — 4 tests, 8 assertions passed.

**Note (pre-existing, unrelated to this change):** `composer test` on the full suite currently aborts mid-run in this environment due to a Brain Monkey/PHPUnit re-definition crash (`Cannot redeclare wp_parse_url()`) and several out-of-date suites (`CacheTest`, `ImgConverterTest`, `InlineCssTest`, `MainBlockAssetsTest`) fail on clean `master` before any change. This was confirmed by running the suite on a stashed (unmodified) tree. The new test suite passes in isolation.

## Files Changed

- `includes/class-main.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-562`.*