### PR TITLE
[Autofix] Lowercase domain in Advanced_Cache_Handler::create() for cache path consistency

### DIFF
--- a/includes/class-advanced-cache-handler.php
+++ b/includes/class-advanced-cache-handler.php
@@ -134,7 +134,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Advanced_Cache_Handler' ) ) {
 			'$site_url       = \'' . $site_url . '\';' . PHP_EOL .
 			'$root_directory = $_SERVER[\'DOCUMENT_ROOT\'];' . PHP_EOL .
 			'$raw_domain    = isset( $_SERVER[\'HTTP_HOST\'] ) ? (string) $_SERVER[\'HTTP_HOST\'] : \'\';' . PHP_EOL .
-			'$site_domain   = preg_replace( \'/[^a-z0-9.:-]+/i\', \'\', $raw_domain );' . PHP_EOL .
+			'$site_domain   = strtolower( preg_replace( \'/[^a-z0-9.:-]+/i\', \'\', $raw_domain ) );' . PHP_EOL .
 			'$request_uri   = isset( $_SERVER[\'REQUEST_URI\'] ) ? (string) parse_url( $_SERVER[\'REQUEST_URI\'], PHP_URL_PATH ) : \'\';' . PHP_EOL .
 			'$request_uri   = rawurldecode( $request_uri );' . PHP_EOL .
 			'$request_uri   = function_exists( \'wp_normalize_path\' ) ? wp_normalize_path( $request_uri ) : str_replace( \'\\\\\', \'/\', $request_uri );' . PHP_EOL . PHP_EOL .

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -167,7 +167,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 			if ( ! $valid_domain ) {
 				$domain = '';
 			} else {
-				$domain = $host;
+				$domain = strtolower( $host );
 			}
 
 			$this->domain = $domain;

--- a/includes/class-used-css.php
+++ b/includes/class-used-css.php
@@ -154,7 +154,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Used_CSS' ) ) {
 				! preg_match( '/^[a-z0-9\.\-]+$/i', $host )
 			);
 
-			$this->domain = $valid_domain ? $host : '';
+			$this->domain = $valid_domain ? strtolower( $host ) : '';
 
 			$this->cache_root_dir = wp_normalize_path( WP_CONTENT_DIR . self::CACHE_ROOT_DIR );
 			$this->cache_root_url = WP_CONTENT_URL . self::CACHE_ROOT_DIR;


### PR DESCRIPTION
## Fixes #566

## What Was Changed

### What Was Done

The `advanced-cache.php` drop-in's cache-lookup domain and the cache write-side domain normalization were both aligned to lowercase so static-page cache lookups and writes resolve to the same directory (`wppo/example.com/`) even when a request's `HTTP_HOST` carries uppercase characters (e.g. `Example.Com`).

### Approach

Hostnames are case-insensitive, but the cache stores files under a domain-named directory. The generated drop-in built its lookup path from the raw `HTTP_HOST` casing, while the write sides (Cache and Used_CSS) preserved a subset of case — so on servers with uppercase hosts the drop-in looked in `wppo/Example.Com/` while writes landed in `wppo/example.com/`, producing a cache miss and a silent fallback to the full WordPress render.

Per the maintainer's decision (Option A, the complete fix), both read and write sides are normalized. Applying `strtolower()` only on the drop-in would have mirrored the mismatch in the opposite direction, so both sides were updated together for true consistency. Lowercasing is applied after validation so it cannot weaken or change validation results.

### Key Changes

- **`includes/class-advanced-cache-handler.php`** (`create()`): wrapped the generated `$site_domain` computation in `strtolower()` so the drop-in always looks up the cache path under the lowercase domain.
- **`includes/class-cache.php`** (constructor): lowercased the validated `$host` before assigning `$this->domain`, so all write/invalidation paths use the same lowercase layout the drop-in reads.
- **`includes/class-used-css.php`** (constructor): applied the same `strtolower()` normalization to `$this->domain` so used-CSS / CCSS cache paths stay consistent with the core cache layout.

Verification: `npm run lint:js` (1 pre-existing unrelated warning), `composer lint`, `npm test` (255 passed), and `npm run build` all complete successfully.

## Files Changed

- `includes/class-advanced-cache-handler.php`
- `includes/class-cache.php`
- `includes/class-used-css.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-566`.*