### PR TITLE
[Autofix] Validate resolved local path bounds in Util::get_local_path()

### DIFF
--- a/includes/class-util.php
+++ b/includes/class-util.php
@@ -118,8 +118,18 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Util' ) ) {
 				}
 			}
 
-			// Return the full local path.
-			return wp_normalize_path( ABSPATH . ltrim( $relative_path, '/' ) );
+			// Build the full local path and verify it stays within ABSPATH.
+			$normalized_abspath = wp_normalize_path( ABSPATH );
+			$full_path          = wp_normalize_path( ABSPATH . ltrim( $relative_path, '/' ) );
+
+			// Enforce ABSPATH prefix bounds. normalized_abspath ends with a '/', so a
+			// 0-offset prefix match guarantees the path is a descendant of ABSPATH
+			// (a sibling directory such as "/path/abspath2" cannot prefix-match).
+			if ( 0 !== strpos( $full_path, $normalized_abspath ) ) {
+				return '';
+			}
+
+			return $full_path;
 		}
 
 		/**

--- a/tests/php/UtilGetLocalPathTest.php
+++ b/tests/php/UtilGetLocalPathTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for Util::get_local_path() ABSPATH bounds validation.
+ *
+ * @package PerformanceOptimise\Tests
+ */
+
+use PerformanceOptimise\Inc\Util;
+use Brain\Monkey\Functions;
+
+/**
+ * Tests for Util::get_local_path() ABSPATH bounds validation.
+ *
+ * @package PerformanceOptimise\Tests
+ */
+class UtilGetLocalPathTest extends \PHPUnit\Framework\TestCase {
+	use WPPO_Test_Bootstrap;
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @before
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'wp_parse_url' )->alias(
+			static function ( $url, $component = -1 ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Emulates wp_parse_url() in tests.
+				$parts = parse_url( $url );
+				if ( false === $parts ) {
+					return false;
+				}
+				if ( -1 !== $component ) {
+					return $parts[ $component ] ?? null;
+				}
+				return $parts;
+			}
+		);
+		Functions\when( 'wp_normalize_path' )->alias(
+			static function ( $path ) {
+				$path = str_replace( '\\', '/', $path );
+				$path = preg_replace( '|(?<=.)/+|', '/', $path );
+				if ( str_starts_with( $path, '//' ) ) {
+					$path = '/' . ltrim( $path, '/' );
+				}
+				return $path;
+			}
+		);
+		Functions\when( 'home_url' )->alias(
+			static function () {
+				return 'http://example.com';
+			}
+		);
+	}
+
+	/**
+	 * Test that a legitimate URL resolving inside ABSPATH returns the path.
+	 */
+	public function test_legitimate_url_inside_abspath_returns_path(): void {
+		$this->assertSame(
+			'/tmp/wordpress/wp-content/themes/my-theme/style.css',
+			Util::get_local_path( 'http://example.com/wp-content/themes/my-theme/style.css' )
+		);
+	}
+
+	/**
+	 * Test that an empty relative path resolves to ABSPATH itself.
+	 */
+	public function test_root_url_resolves_to_abspath(): void {
+		$this->assertSame(
+			'/tmp/wordpress/',
+			Util::get_local_path( 'http://example.com/' )
+		);
+	}
+
+	/**
+	 * Test that a cousin-prefixed directory (e.g. wp-content2) is treated as
+	 * inside ABSPATH, not rejected as a false positive of the bounds check.
+	 */
+	public function test_cousin_prefix_dir_is_not_false_positive(): void {
+		// '/tmp/wordpress/wp-content2/...' genuinely lives inside ABSPATH.
+		$this->assertSame(
+			'/tmp/wordpress/wp-content2/outside/file.css',
+			Util::get_local_path( 'http://example.com/wp-content2/outside/file.css' )
+		);
+	}
+
+	/**
+	 * Test that an out-of-bounds path resolves to '' after normalization.
+	 */
+	public function test_out_of_bounds_relative_path_returns_empty(): void {
+		$this->assertSame(
+			'',
+			Util::get_local_path( 'http://example.com/../../etc/passwd' )
+		);
+	}
+
+	/**
+	 * Test that an unparseable URL returns ''.
+	 */
+	public function test_invalid_url_returns_empty(): void {
+		Functions\when( 'wp_parse_url' )->justReturn( false );
+		$this->assertSame( '', Util::get_local_path( '://not-a-url' ) );
+	}
+
+	/**
+	 * Test that a directory directly inside ABSPATH passes the boundary check.
+	 */
+	public function test_direct_child_dir_is_accepted(): void {
+		$this->assertSame(
+			'/tmp/wordpress/wp-content',
+			Util::get_local_path( 'http://example.com/wp-content' )
+		);
+	}
+}


### PR DESCRIPTION
## Fixes #568

## What Was Changed

### What Was Done

Hardened `Util::get_local_path()` (`includes/class-util.php`) so the final normalized path is verified to stay within the WordPress root before it is returned, instead of relying solely on the earlier `..` substring rejection. If the assembled result does not fall under `ABSPATH`, the method now returns `''` (matching existing behavior for traversal/invalid inputs) so downstream filesystem readers (`Cache::fetch_remote_css()`, minify, image handlers, etc.) can never resolve a file outside the WordPress directory.

### Approach

Following the issue's recommended Option A (minimal bounds check), the method now:

1. Computes `$normalized_abspath = wp_normalize_path( ABSPATH )` and `$full_path = wp_normalize_path( ABSPATH . ltrim( $relative_path, '/' ) )`.
2. Returns `''` unless `$full_path` starts with `$normalized_abspath` (checked via a `0 === strpos()` prefix comparison, not `in_array`, so sibling-prefix escapes are excluded).
3. Because `php_normalize_path()` preserves the trailing `/` of `ABSPATH`, the 0-offset prefix match guarantees the result is a true descendant of the WordPress root and cannot accidentally match a sibling directory such as `/path/abspath2`.

This is a defense-in-depth guard — no existing callers needed changes, as all already tolerate an `''` return for missing/out-of-bounds paths. Behavior for all currently valid URLs is unchanged.

### Key Changes

- **`includes/class-util.php`** — Replaced the unconditional `return wp_normalize_path( ... )` with a bounds-checked return that validates the resolved path stays within `ABSPATH`, returning `''` when it does not.
- **`tests/php/UtilGetLocalPathTest.php`** (new) — Added a focused test suite using the `WPPO_Test_Bootstrap` trait and Brain Monkey stubs (`wp_parse_url`, `wp_normalize_path`, `home_url`, `get_current_blog_id`) covering: legitimate in-root URLs resolve to the expected path; root URL resolves to `ABSPATH`; an unparseable URL returns `''`; `..` traversal resolves to `''`; and a cousin-prefixed sub-directory is not falsely rejected by the bounds check.

Note: The full `composer test` run in this repository is blocked by a pre-existing, unrelated Patchwork fatal (`Cannot redeclare wp_parse_url()`) that occurs on the clean `master` branch and is not introduced by these changes. The new test suite passes in isolation (`composer test -- --filter UtilGetLocalPathTest` → OK), and `npm run lint:js`, `composer lint`, `npm test`, and `npm run build` all pass.

## Files Changed

- `includes/class-util.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-568`.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local path validation to prevent access to paths outside the application’s permitted directory.
  * Invalid URLs and directory traversal attempts now return an empty path instead of an unsafe location.

* **Tests**
  * Added coverage for valid paths, root and child directories, similarly named directories, invalid URLs, and out-of-bounds paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->