### PR TITLE
[Autofix] Remove dead private method Telemetry::measure_ttfb()

### DIFF
--- a/includes/class-telemetry.php
+++ b/includes/class-telemetry.php
@@ -473,32 +473,6 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Telemetry' ) ) {
 		}
 
 		/**
-		 * Measure Time to First Byte (TTFB) in milliseconds via GET request.
-		 *
-		 * Performs a full GET as a more representative TTFB fallback (some servers
-		 * bypass full PHP execution for HEAD requests).
-		 *
-		 * @since  1.5.0
-		 * @param  string $url The URL to measure.
-		 * @return float TTFB in milliseconds, rounded to 2 decimal places.
-		 */
-		private static function measure_ttfb( string $url ): float {
-			$start = microtime( true );
-			wp_remote_get(
-				$url,
-				array(
-					'timeout'   => 10,
-					'sslverify' => (bool) apply_filters( 'wppo_telemetry_verify_ssl', true, $url ),
-				)
-			);
-			// TTFB is essentially the time until we start receiving the response body,
-			// which wp_remote_get returns after the whole body is fetched, but for a
-			// basic fallback, timing the full GET is more representative of rendering
-			// path than timing a HEAD request which often bypasses full PHP execution.
-			return round( ( microtime( true ) - $start ) * 1000, 2 );
-		}
-
-		/**
 		 * Check whether the URL uses HTTPS.
 		 *
 		 * Returns a locale-independent boolean string so frontend comparisons


### PR DESCRIPTION
## Fixes #570

## What Was Changed

# Fix Summary: Remove dead private method Telemetry::measure_ttfb()

## What Was Done
Removed the dead `private static function measure_ttfb()` (and its docblock) from `includes/class-telemetry.php`. The method was never invoked anywhere in the codebase — real TTFB timing is measured directly inside `scan()` using cURL info fields (`starttransfer_time` with a total-time fallback).

## Approach
This was a surgical dead-code removal following Option A from the implementation plan. I verified the method name appeared exactly once in the entire repo (its own definition) and confirmed no PHP or JS tests reference telemetry timing. The removal has zero behavioral impact since the cURL-based timing path in `scan()` is the only active implementation.

## Key Changes
- `includes/class-telemetry.php` — Deleted the `measure_ttfb()` method (~25 lines including its docblock), which was a leftover `wp_remote_get()`-based helper that would never run and documented a misleading HEAD/GET fallback that is not part of the active timing flow.

## Verification
All checks pass:
- `npm run lint:js` — pass (1 pre-existing warning in `ObjectCache.js`, unrelated)
- `composer lint` — pass
- `npm test` — 23 suites / 255 tests pass
- `npm run build` — pass

## Files Changed

- `includes/class-telemetry.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-570`.*