### PR TITLE
[Autofix] Safeguard array_diff in Main::add_available_post_types_to_options()

### DIFF
--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -1201,6 +1201,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 		private function add_available_post_types_to_options() {
 			$post_types = get_post_types( array( 'public' => true ), 'names' );
 
+			if ( ! is_array( $post_types ) ) {
+				$post_types = array();
+			}
+
 			$excluded            = array( 'attachment' );
 			$filtered_post_types = array_keys( array_diff( $post_types, $excluded ) );
 

--- a/tests/php/MainAvailablePostTypesTest.php
+++ b/tests/php/MainAvailablePostTypesTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests for Main::add_available_post_types_to_options().
+ *
+ * Verifies that the get_post_types() result is safeguarded with an is_array()
+ * check before being passed to array_diff(), and that availablePostTypes is
+ * always populated with a sane value (all public types minus 'attachment').
+ *
+ * @package PerformanceOptimise\Tests
+ */
+
+use PerformanceOptimise\Inc\Main;
+use Brain\Monkey\Functions;
+
+/**
+ * Tests the add_available_post_types_to_options() private method.
+ *
+ * @package PerformanceOptimise\Tests
+ */
+class MainAvailablePostTypesTest extends \PHPUnit\Framework\TestCase {
+	use WPPO_Test_Bootstrap;
+
+	/**
+	 * Stub the WP environment needed to construct Main.
+	 *
+	 * @return void
+	 */
+	private function stub_main_construction(): void {
+		Functions\stubs(
+			array(
+				'WP_Filesystem'       => false,
+				'sanitize_text_field' => '',
+				'wp_unslash'          => '',
+				'is_user_logged_in'   => false,
+			)
+		);
+
+		Functions\when( 'get_option' )->alias(
+			static function ( $option, $default_value = false ) {
+				return $default_value;
+			}
+		);
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\when( 'wp_normalize_path' )->returnArg();
+		Functions\when( 'content_url' )->returnArg();
+		Functions\when( 'trailingslashit' )->returnArg();
+		Functions\when( 'wp_is_block_theme' )->justReturn( false );
+		Functions\when( 'get_bloginfo' )->justReturn( '6.8' );
+
+		Functions\when( 'function_exists' )->alias(
+			static function ( $function_name ) {
+				if ( 'WP_Filesystem' === $function_name || 'wp_is_block_theme' === $function_name ) {
+					return true;
+				}
+				return \function_exists( $function_name );
+			}
+		);
+	}
+
+	/**
+	 * Invoke the private add_available_post_types_to_options() method and
+	 * return the resulting availablePostTypes option.
+	 *
+	 * @param mixed $post_types_return The value get_post_types() should return.
+	 * @return mixed The availablePostTypes option value.
+	 */
+	private function run_method_with_post_types( $post_types_return ) {
+		Functions\when( 'get_post_types' )->justReturn( $post_types_return );
+
+		$main = new Main();
+
+		$reflection = new \ReflectionMethod( Main::class, 'add_available_post_types_to_options' );
+		$reflection->setAccessible( true );
+		$reflection->invoke( $main );
+
+		$options_reflection = new \ReflectionProperty( Main::class, 'options' );
+		$options_reflection->setAccessible( true );
+		$options = $options_reflection->getValue( $main );
+
+		return $options['image_optimisation']['availablePostTypes'] ?? null;
+	}
+
+	/**
+	 * Test that a normal array input returns all public post types minus
+	 * 'attachment'.
+	 */
+	public function test_returns_public_post_types_excluding_attachment(): void {
+		$this->stub_main_construction();
+
+		$result = $this->run_method_with_post_types(
+			array(
+				'post'          => 'post',
+				'page'          => 'page',
+				'attachment'    => 'attachment',
+				'product'       => 'product',
+				'revision'      => 'revision',
+				'nav_menu_item' => 'nav_menu_item',
+			)
+		);
+
+		$this->assertContains( 'post', $result );
+		$this->assertContains( 'page', $result );
+		$this->assertContains( 'product', $result );
+		$this->assertContains( 'revision', $result );
+		$this->assertNotContains( 'attachment', $result );
+		$this->assertContains( 'nav_menu_item', $result );
+	}
+
+	/**
+	 * Test that a non-array (false) return from get_post_types() does not cause
+	 * an error and results in an empty availablePostTypes array.
+	 */
+	public function test_non_array_post_types_returns_empty_array_without_error(): void {
+		$this->stub_main_construction();
+
+		$result = $this->run_method_with_post_types( false );
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that a null return from get_post_types() also resolves safely to an
+	 * empty array.
+	 */
+	public function test_null_post_types_returns_empty_array_without_error(): void {
+		$this->stub_main_construction();
+
+		$result = $this->run_method_with_post_types( null );
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+}


### PR DESCRIPTION
## Fixes #572

## What Was Changed

### What Was Done

Hardened `Main::add_available_post_types_to_options()` in `includes/class-main.php` so the result of `get_post_types()` is validated with `is_array()` before being passed to `array_diff()`, preventing a PHP warning/TypeError under PHP 8.x if a third-party plugin/filter returns a non-array value. A Brain Monkey unit test was added to cover both the normal path and the defensive fallback.

### Approach

`add_available_post_types_to_options()` consumed `get_post_types()` output directly inside `array_diff( $post_types, $excluded )`. `array_diff()` is type-strict about array arguments, so any non-array return from the WP core function (e.g. a broken filter returning `false`/`null`) would trigger a PHP warning/TypeError on the `wppo` admin screen.

The fix applies **Option A** (the recommended, minimal approach from the implementation plan): guard the value with `is_array()` and fall back to an empty array before the `array_diff()` call. This preserves the existing normal behavior (all public post types minus `attachment`) with zero behavioral change, while making the broken-value path resolve safely to an empty `availablePostTypes` list instead of erroring.

### Key Changes

- **`includes/class-main.php`** — Added an `if ( ! is_array( $post_types ) ) { $post_types = array(); }` guard just before the `array_diff()` call in `add_available_post_types_to_options()`. This is the exact, targeted fix requested in the issue and mirrors the defensive checks used elsewhere in the codebase.
- **`tests/php/MainAvailablePostTypesTest.php`** (new) — Brain Monkey test that stubs Main construction, reflects into the private `add_available_post_types_to_options( )` method, and asserts:
  - Normal array input returns all public post types minus `attachment` (and keeps other non-attachment types).
  - A non-array return (`false`) from `get_post_types()` yields an empty `availablePostTypes` array without error.
  - A `null` return resolves safely to an empty array.

Verification: `composer lint` passes (exit 0). The new test passes (`composer test` for `MainAvailablePostTypesTest`: 3 tests, 10 assertions OK). No JS changes were made. Note: `MainBlockAssetsTest` currently reports errors due to an un-mocked `get_bloginfo` in its own stub — this failure is pre-existing on the base branch and unrelated to this issue.

## Files Changed

- `includes/class-main.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-572`.*