### PR TITLE
[Autofix] Skip empty keys in Rest::sanitize_settings_recursively()

### DIFF
--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -416,6 +416,12 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Rest' ) ) {
 			foreach ( $settings as $key => $value ) {
 				$safe_key = preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key );
 
+				// Skip keys that become empty after sanitization so that
+				// settings are never stored under an empty-string key.
+				if ( '' === $safe_key ) {
+					continue;
+				}
+
 				if ( is_array( $value ) ) {
 					$sanitized[ $safe_key ] = $this->sanitize_settings_recursively( $value );
 				} elseif ( is_bool( $value ) ) {

--- a/tests/php/RestTest.php
+++ b/tests/php/RestTest.php
@@ -139,6 +139,33 @@ class RestTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Test that sanitize_settings_recursively skips keys that become empty
+	 * after sanitization (e.g. keys made only of non a-zA-Z0-9_- characters
+	 * or empty keys) so they are never stored under an empty-string key.
+	 */
+	public function test_sanitize_settings_recursively_skips_empty_keys(): void {
+		$reflection = new ReflectionMethod( $this->rest, 'sanitize_settings_recursively' );
+		$reflection->setAccessible( true );
+
+		$result = $reflection->invoke(
+			$this->rest,
+			array(
+				'@@@'        => 'x',
+				'normal_key' => 'value',
+				'nested'     => array(
+					'!!' => 'y',
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey( '', $result, 'Empty-string key must not be present at the top level' );
+		$this->assertArrayNotHasKey( '', $result['nested'], 'Empty-string key must not be present in nested arrays' );
+		$this->assertArrayHasKey( 'normal_key', $result );
+		$this->assertSame( 'value', $result['normal_key'] );
+		$this->assertSame( array(), $result['nested'] );
+	}
+
+	/**
 	 * Test that each route has a permission callback.
 	 */
 	public function test_each_route_has_permission_callback(): void {


### PR DESCRIPTION
## Fixes #574

## What Was Changed

# Skip empty keys in `Rest::sanitize_settings_recursively()`

### What Was Done
Fixed a data-integrity bug in `includes/class-rest.php` where a settings key made entirely of non-`a-zA-Z0-9_-` characters (e.g. `@@@`, `!!!`, or an empty key) was sanitized to an empty string and written into the sanitized array under the `''` key, polluting the persisted `wppo_settings` option. The fix skips keys that become empty after sanitization and adds a regression test.

### Approach
`sanitize_settings_recursively()` strips every character that is not `[a-zA-Z0-9_-]` from each array key via `preg_replace()`. If no valid characters remain (or the key was already empty), `$safe_key` becomes `''` and was unconditionally assigned into the result. Since the same helper feeds both `update_settings` (stored at `$options[ $tab ]`) and `import_settings` (merged via `array_replace_recursive()`), the empty-string key could end up persisted in the database.

The fix adds a minimal guard immediately after `$safe_key` is computed: if `'' === $safe_key`, the key/value pair is dropped entirely. Because the recursive call returns through the same guard, nested invalid keys are covered too. All existing value-sanitization branches are preserved.

### Key Changes
- `includes/class-rest.php:419-423` — Added a `continue` guard in `sanitize_settings_recursively()` that skips any key that sanitizes to an empty string, so settings are never stored under an empty-string key.
- `tests/php/RestTest.php` — Added `test_sanitize_settings_recursively_skips_empty_keys()`, a regression test that invokes the private method via reflection and asserts: no `''` key at the top level or in nested arrays, and that valid keys/values are preserved.

## Files Changed

- `includes/class-rest.php`
- `tests/php/RestTest.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-574`.*