### PR TITLE
[Autofix] Harden Image_Optimisation memory bounds and size cache eviction logic

### DIFF
--- a/includes/class-image-optimisation.php
+++ b/includes/class-image-optimisation.php
@@ -34,6 +34,23 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 		private const MAX_PRELOAD_WIDTH = 1478;
 
 		/**
+		 * Maximum dimension (px) for the generated SVG placeholder.
+		 *
+		 * Guards against malformed or extreme width/height attributes so
+		 * placeholders cannot bloat memory or break layout.
+		 *
+		 * @since 1.9.1
+		 */
+		private const SVG_PLACEHOLDER_MAX_DIMENSION = 4096;
+
+		/**
+		 * Maximum number of entries retained in the per-request image-size cache.
+		 *
+		 * @since 1.9.1
+		 */
+		private const IMG_SIZE_CACHE_LIMIT = 100;
+
+		/**
 		 * Configuration options for image optimization.
 		 *
 		 * @var array
@@ -278,13 +295,18 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 						$local_path = Util::get_local_path( $data_src );
 						if ( ! empty( $local_path ) && file_exists( $local_path ) && is_readable( $local_path ) && is_file( $local_path ) ) {
 							static $img_size_cache = array();
-							if ( ! isset( $img_size_cache[ $local_path ] ) ) {
-								if ( count( $img_size_cache ) >= 100 ) {
+
+							if ( isset( $img_size_cache[ $local_path ] ) ) {
+								$size = $img_size_cache[ $local_path ];
+								unset( $img_size_cache[ $local_path ] );
+								$img_size_cache[ $local_path ] = $size;
+							} else {
+								if ( count( $img_size_cache ) >= self::IMG_SIZE_CACHE_LIMIT ) {
 									array_shift( $img_size_cache );
 								}
 								$img_size_cache[ $local_path ] = getimagesize( $local_path );
+								$size                          = $img_size_cache[ $local_path ];
 							}
-							$size = $img_size_cache[ $local_path ];
 							if ( is_array( $size ) ) {
 								if ( ! $has_width ) {
 									$img_tag = preg_replace( '/<img\b/i', '<img width="' . (int) $size[0] . '"', $img_tag, 1 );
@@ -1345,14 +1367,17 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 					if ( ! empty( $local_path ) && file_exists( $local_path ) && is_readable( $local_path ) && is_file( $local_path ) ) {
 						static $img_size_cache = array();
 
-						if ( ! isset( $img_size_cache[ $local_path ] ) ) {
-							if ( count( $img_size_cache ) >= 100 ) {
+						if ( isset( $img_size_cache[ $local_path ] ) ) {
+							$size = $img_size_cache[ $local_path ];
+							unset( $img_size_cache[ $local_path ] );
+							$img_size_cache[ $local_path ] = $size;
+						} else {
+							if ( count( $img_size_cache ) >= self::IMG_SIZE_CACHE_LIMIT ) {
 								array_shift( $img_size_cache );
 							}
 							$img_size_cache[ $local_path ] = getimagesize( $local_path );
+							$size                          = $img_size_cache[ $local_path ];
 						}
-
-						$size = $img_size_cache[ $local_path ];
 
 						if ( is_array( $size ) ) {
 							if ( ! $has_width ) {
@@ -2386,8 +2411,8 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 			preg_match( '/\bwidth=["\']?(\d+)["\']?/i', $img_attributes, $width_matches );
 			preg_match( '/\bheight=["\']?(\d+)["\']?/i', $img_attributes, $height_matches );
 
-			$width  = isset( $width_matches[1] ) ? absint( $width_matches[1] ) : 100;
-			$height = isset( $height_matches[1] ) ? absint( $height_matches[1] ) : 100;
+			$width  = isset( $width_matches[1] ) ? min( absint( $width_matches[1] ), self::SVG_PLACEHOLDER_MAX_DIMENSION ) : 100;
+			$height = isset( $height_matches[1] ) ? min( absint( $height_matches[1] ), self::SVG_PLACEHOLDER_MAX_DIMENSION ) : 100;
 
 			$svg_content = '<svg xmlns="http://www.w3.org/2000/svg" width="' . $width . '" height="' . $height . '" viewBox="0 0 ' . $width . ' ' . $height . '"><rect width="100%" height="100%" fill="' . esc_attr( $color ) . '" /></svg>';
 

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,6 +1,10 @@
 {
     "redefinable-internals": [
         "function_exists",
-        "idn_to_ascii"
+        "idn_to_ascii",
+        "file_exists",
+        "is_readable",
+        "is_file",
+        "getimagesize"
     ]
 }

--- a/tests/php/ImageOptimisationTest.php
+++ b/tests/php/ImageOptimisationTest.php
@@ -440,6 +440,130 @@ class ImageOptimisationTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Stub the WP functions used to resolve a URL to a local path via
+	 * Util::get_local_path().
+	 */
+	private function stub_local_path_resolution(): void {
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'wp_parse_url' )->alias(
+			static function ( $url, $component = -1 ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Emulates wp_parse_url() in tests.
+				$parts = parse_url( $url );
+				if ( false === $parts ) {
+					return false;
+				}
+				if ( -1 !== $component ) {
+					return $parts[ $component ] ?? null;
+				}
+				return $parts;
+			}
+		);
+		Functions\when( 'wp_normalize_path' )->alias(
+			static function ( $path ) {
+				$path = str_replace( '\\', '/', $path );
+				$path = preg_replace( '|(?<=.)/+|', '/', $path );
+				if ( str_starts_with( $path, '//' ) ) {
+					$path = '/' . ltrim( $path, '/' );
+				}
+				return $path;
+			}
+		);
+		Functions\when( 'home_url' )->alias(
+			static function () {
+				return 'http://example.com';
+			}
+		);
+	}
+
+	/**
+	 * Test that generate_svg_base64 caps extreme width/height attributes.
+	 */
+	public function test_generate_svg_base64_caps_extreme_dimensions(): void {
+		Functions\when( 'esc_attr' )->returnArg();
+
+		$image_opt = new Image_Optimisation( $this->default_options );
+
+		$reflection = new \ReflectionMethod( Image_Optimisation::class, 'generate_svg_base64' );
+		$reflection->setAccessible( true );
+
+		$result = $reflection->invoke( $image_opt, '<img width="999999" height="500000" />' );
+
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding test fixture output.
+		$svg = base64_decode( str_replace( 'data:image/svg+xml;base64,', '', $result ), true );
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+		$this->assertIsString( $svg );
+		$this->assertStringContainsString( 'width="4096"', $svg );
+		$this->assertStringContainsString( 'height="4096"', $svg );
+		$this->assertStringContainsString( 'viewBox="0 0 4096 4096"', $svg );
+	}
+
+	/**
+	 * Test that generate_svg_base64 preserves legitimate dimensions.
+	 */
+	public function test_generate_svg_base64_preserves_normal_dimensions(): void {
+		Functions\when( 'esc_attr' )->returnArg();
+
+		$image_opt = new Image_Optimisation( $this->default_options );
+
+		$reflection = new \ReflectionMethod( Image_Optimisation::class, 'generate_svg_base64' );
+		$reflection->setAccessible( true );
+
+		$result = $reflection->invoke( $image_opt, '<img width="800" height="600" />' );
+
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding test fixture output.
+		$svg = base64_decode( str_replace( 'data:image/svg+xml;base64,', '', $result ), true );
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+		$this->assertIsString( $svg );
+		$this->assertStringContainsString( 'width="800"', $svg );
+		$this->assertStringContainsString( 'height="600"', $svg );
+		$this->assertStringContainsString( 'viewBox="0 0 800 600"', $svg );
+	}
+
+	/**
+	 * Test that the img_size_cache refreshes key recency on hit so frequently
+	 * accessed images survive cache eviction (true LRU ordering).
+	 */
+	public function test_img_size_cache_refreshes_lru_order(): void {
+		$this->stub_local_path_resolution();
+		Functions\when( 'file_exists' )->justReturn( true );
+		Functions\when( 'is_readable' )->justReturn( true );
+		Functions\when( 'is_file' )->justReturn( true );
+
+		$getimagesize_calls = 0;
+		Functions\when( 'getimagesize' )->alias(
+			static function () use ( &$getimagesize_calls ) {
+				++$getimagesize_calls;
+				return array( 100, 100, 1, 1, 'image/jpeg' );
+			}
+		);
+
+		$image_opt = new Image_Optimisation( $this->default_options );
+
+		// Insert 100 unique images, then refresh the first key, insert a 101st
+		// image (triggering eviction), and re-access the first key.
+		$buffer = '';
+		for ( $i = 0; $i < 100; $i++ ) {
+			$buffer .= '<img data-src="http://example.com/wp-content/uploads/lru-' . $i . '.jpg" />';
+		}
+		$buffer .= '<img data-src="http://example.com/wp-content/uploads/lru-0.jpg" />';
+		$buffer .= '<img data-src="http://example.com/wp-content/uploads/lru-100.jpg" />';
+		$buffer .= '<img data-src="http://example.com/wp-content/uploads/lru-0.jpg" />';
+
+		$reflection = new \ReflectionMethod( Image_Optimisation::class, 'post_process_img_dimensions' );
+		$reflection->setAccessible( true );
+
+		$result = $reflection->invoke( $image_opt, $buffer );
+
+		// 100 initial reads + 1 for the 101st image. The refreshed first key
+		// must remain cached (a FIFO eviction would evict it and re-read it,
+		// bumping the count to 102).
+		$this->assertSame( 101, $getimagesize_calls );
+		$this->assertStringContainsString( 'width="100"', $result );
+	}
+
+	/**
 	 * Test that a non-array client-side MIME setting (corrupted storage) keeps
 	 * core's default list untouched (graceful degradation).
 	 */


### PR DESCRIPTION
## Fixes #576

## What Was Changed

# Fix Summary: Harden Image_Optimisation memory bounds and size cache eviction logic

## What Was Done

Hardened `Image_Optimisation` by capping the SVG placeholder dimensions parsed from `width`/`height` attributes (preventing malformed/extreme values from bloating memory or breaking layout) and converted the per-request `img_size_cache` from FIFO to true Least-Recently-Used (LRU) eviction so frequently accessed images are no longer evicted first.

## Approach

1. **SVG placeholder cap** — `generate_svg_base64()` previously passed `absint()` output straight into the SVG markup, so a value like `width="999999"` produced an oversized placeholder that inflates intrinsic layout dimensions and grows the base64 payload. The parsed values are now clamped with `min()` against a new `SVG_PLACEHOLDER_MAX_DIMENSION = 4096` constant before being embedded.

2. **True LRU eviction** — The `img_size_cache` static array (used in both `post_process_img_dimensions()` and `process_img_tag()`) inserted new entries and, when full at 100, evicted the oldest-inserted key via `array_shift()`. Because cache hits never refreshed key order, frequently re-used images were treated as oldest and evicted first, forcing repeated `getimagesize()` disk reads. Since PHP arrays preserve insertion order, a hit now performs `unset()` + re-assign to move the key to the end of the array, so `array_shift()` always removes the least-recently-used key. Hit performance is unchanged (no re-read of `getimagesize()`).

The hardcoded `100` cache limit was replaced with a new `IMG_SIZE_CACHE_LIMIT` constant.

## Key Changes

- `includes/class-image-optimisation.php`
  - Added `SVG_PLACEHOLDER_MAX_DIMENSION` (4096) and `IMG_SIZE_CACHE_LIMIT` (100) class constants near `MAX_PRELOAD_WIDTH`.
  - `generate_svg_base64()`: clamped `$width`/`$height` with `min( absint(...), SVG_PLACEHOLDER_MAX_DIMENSION )`.
  - `post_process_img_dimensions()`: cache hits now refresh key recency (unset + re-assign) for true LRU eviction; limit uses the constant.
  - `process_img_tag()`: identical LRU refresh applied to the second `img_size_cache` block.

- `tests/php/ImageOptimisationTest.php`
  - `test_generate_svg_base64_caps_extreme_dimensions()` — verifies extreme values are clamped to 4096 in the decoded SVG.
  - `test_generate_svg_base64_preserves_normal_dimensions()` — verifies legitimate dimensions pass through unchanged.
  - `test_img_size_cache_refreshes_lru_order()` — verifies a refreshed key survives eviction (getimagesize call count stays 101). Confirmed this test fails under the old FIFO logic (count becomes 102).

- `patchwork.json` — added `file_exists`, `is_readable`, `is_file`, `getimagesize` to `redefinable-internals` so Brain Monkey can stub these PHP internals in the LRU unit test (test-only infrastructure change, no runtime effect).

## Verification

- `npm run lint:js` — pass (1 pre-existing warning in `src/components/ObjectCache.js`, unrelated)
- `composer lint` — pass
- `npm test` — 255/255 pass
- `npm run build` — compiles successfully, no build-artifact changes
- `composer test` — `ImageOptimisationTest` 21/21 pass. The suite's pre-existing failures (`CacheTest`, `ImgConverterTest`, `InlineCssTest`, `MainBlockAssetsTest` — stale tests referencing removed methods/unmocked functions) were confirmed identical with these changes stashed.

## Files Changed

- `includes/class-image-optimisation.php`
- `patchwork.json`
- `tests/php/ImageOptimisationTest.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-576`.*