### PR TITLE
[Autofix] Harden Image_Optimisation memory bounds and size cache eviction logic

### DIFF
--- a/includes/class-image-optimisation.php
+++ b/includes/class-image-optimisation.php
@@ -34,6 +34,23 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 		private const MAX_PRELOAD_WIDTH = 1478;
 
 		/**
+		 * Maximum dimension (px) for the generated SVG placeholder.
+		 *
+		 * Guards against malformed or extreme width/height attributes so
+		 * placeholders cannot bloat memory or break layout.
+		 *
+		 * @since 1.9.1
+		 */
+		private const SVG_PLACEHOLDER_MAX_DIMENSION = 4096;
+
+		/**
+		 * Maximum number of entries retained in the per-request image-size cache.
+		 *
+		 * @since 1.9.1
+		 */
+		private const IMG_SIZE_CACHE_LIMIT = 100;
+
+		/**
 		 * Configuration options for image optimization.
 		 *
 		 * @var array
@@ -278,13 +295,17 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 						$local_path = Util::get_local_path( $data_src );
 						if ( ! empty( $local_path ) && file_exists( $local_path ) && is_readable( $local_path ) && is_file( $local_path ) ) {
 							static $img_size_cache = array();
-							if ( ! isset( $img_size_cache[ $local_path ] ) ) {
-								if ( count( $img_size_cache ) >= 100 ) {
+							if ( isset( $img_size_cache[ $local_path ] ) ) {
+								$size = $img_size_cache[ $local_path ];
+								unset( $img_size_cache[ $local_path ] );
+								$img_size_cache[ $local_path ] = $size;
+							} else {
+								if ( count( $img_size_cache ) >= self::IMG_SIZE_CACHE_LIMIT ) {
 									array_shift( $img_size_cache );
 								}
 								$img_size_cache[ $local_path ] = getimagesize( $local_path );
+								$size                          = $img_size_cache[ $local_path ];
 							}
-							$size = $img_size_cache[ $local_path ];
 							if ( is_array( $size ) ) {
 								if ( ! $has_width ) {
 									$img_tag = preg_replace( '/<img\b/i', '<img width="' . (int) $size[0] . '"', $img_tag, 1 );
@@ -1345,14 +1366,17 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 					if ( ! empty( $local_path ) && file_exists( $local_path ) && is_readable( $local_path ) && is_file( $local_path ) ) {
 						static $img_size_cache = array();
 
-						if ( ! isset( $img_size_cache[ $local_path ] ) ) {
-							if ( count( $img_size_cache ) >= 100 ) {
+						if ( isset( $img_size_cache[ $local_path ] ) ) {
+							$size = $img_size_cache[ $local_path ];
+							unset( $img_size_cache[ $local_path ] );
+							$img_size_cache[ $local_path ] = $size;
+						} else {
+							if ( count( $img_size_cache ) >= self::IMG_SIZE_CACHE_LIMIT ) {
 								array_shift( $img_size_cache );
 							}
 							$img_size_cache[ $local_path ] = getimagesize( $local_path );
+							$size                          = $img_size_cache[ $local_path ];
 						}
-
-						$size = $img_size_cache[ $local_path ];
 
 						if ( is_array( $size ) ) {
 							if ( ! $has_width ) {
@@ -2386,8 +2410,8 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Image_Optimisation' ) ) {
 			preg_match( '/\bwidth=["\']?(\d+)["\']?/i', $img_attributes, $width_matches );
 			preg_match( '/\bheight=["\']?(\d+)["\']?/i', $img_attributes, $height_matches );
 
-			$width  = isset( $width_matches[1] ) ? absint( $width_matches[1] ) : 100;
-			$height = isset( $height_matches[1] ) ? absint( $height_matches[1] ) : 100;
+			$width  = isset( $width_matches[1] ) ? min( absint( $width_matches[1] ), self::SVG_PLACEHOLDER_MAX_DIMENSION ) : 100;
+			$height = isset( $height_matches[1] ) ? min( absint( $height_matches[1] ), self::SVG_PLACEHOLDER_MAX_DIMENSION ) : 100;
 
 			$svg_content = '<svg xmlns="http://www.w3.org/2000/svg" width="' . $width . '" height="' . $height . '" viewBox="0 0 ' . $width . ' ' . $height . '"><rect width="100%" height="100%" fill="' . esc_attr( $color ) . '" /></svg>';
 

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,6 +1,10 @@
 {
     "redefinable-internals": [
+        "file_exists",
         "function_exists",
-        "idn_to_ascii"
+        "getimagesize",
+        "idn_to_ascii",
+        "is_file",
+        "is_readable"
     ]
 }

--- a/tests/php/ImageOptimisationTest.php
+++ b/tests/php/ImageOptimisationTest.php
@@ -456,4 +456,132 @@ class ImageOptimisationTest extends \PHPUnit\Framework\TestCase {
 		$core = array( 'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif' );
 		$this->assertSame( $core, $image_opt->filter_client_side_supported_mime_types( $core ) );
 	}
+
+	/**
+	 * Test that generate_svg_base64 caps extreme width/height attributes at the
+	 * placeholder maximum to avoid memory bloat and layout breakage.
+	 */
+	public function test_generate_svg_base64_caps_extreme_dimensions(): void {
+		Functions\when( 'wp_normalize_path' )->justReturn( '/tmp' );
+		Functions\when( 'esc_attr' )->returnArg();
+
+		$image_opt = new Image_Optimisation( $this->default_options );
+
+		$reflection = new \ReflectionMethod( Image_Optimisation::class, 'generate_svg_base64' );
+		$reflection->setAccessible( true );
+
+		$result = $reflection->invoke( $image_opt, '<img width="999999" height="500000" />' );
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding the SVG fixture for assertions.
+		$decoded = base64_decode( str_replace( 'data:image/svg+xml;base64,', '', $result ), true );
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		$decoded = false === $decoded ? '' : $decoded;
+
+		$this->assertStringContainsString( 'width="4096"', $decoded );
+		$this->assertStringContainsString( 'height="4096"', $decoded );
+		$this->assertStringContainsString( 'viewBox="0 0 4096 4096"', $decoded );
+	}
+
+	/**
+	 * Test that generate_svg_base64 preserves legitimate width/height attributes
+	 * unchanged (no regression on normal image sizes).
+	 */
+	public function test_generate_svg_base64_preserves_normal_dimensions(): void {
+		Functions\when( 'wp_normalize_path' )->justReturn( '/tmp' );
+		Functions\when( 'esc_attr' )->returnArg();
+
+		$image_opt = new Image_Optimisation( $this->default_options );
+
+		$reflection = new \ReflectionMethod( Image_Optimisation::class, 'generate_svg_base64' );
+		$reflection->setAccessible( true );
+
+		$result = $reflection->invoke( $image_opt, '<img width="800" height="600" />' );
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Decoding the SVG fixture for assertions.
+		$decoded = base64_decode( str_replace( 'data:image/svg+xml;base64,', '', $result ), true );
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		$decoded = false === $decoded ? '' : $decoded;
+
+		$this->assertStringContainsString( 'width="800"', $decoded );
+		$this->assertStringContainsString( 'height="600"', $decoded );
+		$this->assertStringContainsString( 'viewBox="0 0 800 600"', $decoded );
+	}
+
+	/**
+	 * Test that the img_size_cache in post_process_img_dimensions refreshes key
+	 * recency on cache hits so eviction follows true LRU order instead of FIFO.
+	 *
+	 * Uses a unique upload path per invocation to isolate from other tests that
+	 * share the process-wide static cache.
+	 */
+	public function test_img_size_cache_refreshes_lru_order(): void {
+		Functions\when( 'wp_normalize_path' )->alias(
+			static function ( $path ) {
+				return str_replace( '\\', '/', $path );
+			}
+		);
+		Functions\when( 'wp_parse_url' )->alias(
+			static function ( $url, $component = -1 ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Emulates wp_parse_url() in tests.
+				$parts = parse_url( $url );
+				if ( false === $parts ) {
+					return false;
+				}
+				if ( -1 !== $component ) {
+					return $parts[ $component ] ?? null;
+				}
+				return $parts;
+			}
+		);
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'home_url' )->justReturn( 'http://example.com' );
+		Functions\when( 'file_exists' )->justReturn( true );
+		Functions\when( 'is_readable' )->justReturn( true );
+		Functions\when( 'is_file' )->justReturn( true );
+
+		$getimagesize_calls = 0;
+		Functions\when( 'getimagesize' )->alias(
+			static function () use ( &$getimagesize_calls ) {
+				++$getimagesize_calls;
+				return array(
+					100,
+					100,
+					2,
+					'width="100" height="100"',
+					'bits'     => 8,
+					'channels' => 3,
+					'mime'     => 'image/jpeg',
+				);
+			}
+		);
+
+		$image_opt = new Image_Optimisation( $this->default_options );
+
+		$reflection = new \ReflectionMethod( Image_Optimisation::class, 'post_process_img_dimensions' );
+		$reflection->setAccessible( true );
+
+		$img_url = static function ( int $index ): string {
+			return 'http://example.com/wp-content/uploads/lru-isolation-' . $index . '.jpg';
+		};
+
+		// Build a single buffer so all images flow through one processing pass
+		// (the static img_size_cache lives inside the preg_replace_callback closure
+		// and only persists within a single buffer).
+		$buffer = '';
+		for ( $i = 1; $i <= 100; $i++ ) {
+			$buffer .= '<img data-src="' . $img_url( $i ) . '" alt="img ' . $i . '" />';
+		}
+		// Re-access image #1 (cache hit) before inserting a 101st image.
+		$buffer .= '<img data-src="' . $img_url( 1 ) . '" alt="img 1 re-access" />';
+		// Insert image #101: eviction must drop the least-recently-used key
+		// (image #2, since #1 was just refreshed) rather than the oldest insert.
+		$buffer .= '<img data-src="' . $img_url( 101 ) . '" alt="img 101" />';
+		// Re-access image #1 again: under true LRU it survived eviction.
+		$buffer .= '<img data-src="' . $img_url( 1 ) . '" alt="img 1 again" />';
+
+		$reflection->invoke( $image_opt, $buffer );
+
+		// 100 misses for the initial images + 1 miss for #101 = 101 getimagesize()
+		// calls. If image #1 were evicted (FIFO behaviour), the final re-access
+		// would trigger a second read and the count would reach 102.
+		$this->assertSame( 101, $getimagesize_calls );
+	}
 }


### PR DESCRIPTION
## Fixes #576

## What Was Changed

### What Was Done

Hardened `Image_Optimisation` against malformed SVG placeholders and made the per-request image-size cache evict by true Least-Recently-Used (LRU) order instead of first-in-first-out. Both call sites now cap extreme placeholder dimensions and refresh key recency on cache hits.

### Approach

1. **SVG dimension cap** — `generate_svg_base64()` now clamps parsed `width`/`height` attributes with `min( absint( ... ), self::SVG_PLACEHOLDER_MAX_DIMENSION )` (4096px), so malformed or maliciously huge values (e.g. `width="999999"`) can no longer bloat the placeholder SVG or break page layout. Normal dimensions pass through unchanged.

2. **True LRU eviction** — Both `img_size_cache` access paths (`post_process_img_dimensions()` and `process_img_tag()`) previously evicted the oldest *inserted* key via `array_shift()` without ever refreshing any key's recency, so frequently re-read images were dropped first. Each site now performs an `unset()` + re-assign on a cache hit to move the key to the back of the array (PHP preserves array insertion order), making `array_shift()` always evict the least-recently-used entry. Hit cost is unchanged — no `getimagesize()` re-read.

3. **New class constants** — `SVG_PLACEHOLDER_MAX_DIMENSION = 4096` and `IMG_SIZE_CACHE_LIMIT = 100` placed alongside the existing `MAX_PRELOAD_WIDTH`, replacing the previously hard-coded `100` magic numbers.

### Key Changes

- `includes/class-image-optimisation.php`
  - Added `SVG_PLACEHOLDER_MAX_DIMENSION` and `IMG_SIZE_CACHE_LIMIT` constants.
  - Capped `$width`/`$height` in `generate_svg_base64()`.
  - Replaced both `img_size_cache` blocks with LRU refresh (`unset()` + re-assign on hit; `array_shift()` only on full-miss eviction).

- `tests/php/ImageOptimisationTest.php`
  - `test_generate_svg_base64_caps_extreme_dimensions()` — verifies `999999`/`500000` are capped to `4096`.
  - `test_generate_svg_base64_preserves_normal_dimensions()` — verifies legitimate sizes (`800`/`600`) are unchanged.
  - `test_img_size_cache_refreshes_lru_order()` — exercises a single buffer of 100 unique images, a refresh hit, an eviction trigger (101st image), and a final re-access; asserts `getimagesize()` is called exactly 101 times (would be 102 under the old FIFO logic because the refreshed key gets evicted).

- `patchwork.json`
  - Added `file_exists`, `getimagesize`, `is_file`, `is_readable` to `redefinable-internals` so the LRU test can stub filesystem/toolchain primitives without Patchwork rejecting them.

### Verification

Run in the required order, all passing:
1. `npm run lint:js` — 0 errors (1 pre-existing warning in `ObjectCache.js`, unrelated).
2. `composer lint` — 0 errors, 0 warnings.
3. `npm test` — 255 tests passed.
4. `npm run build` — webpack compiled successfully.

Note: The full `composer test` suite terminates mid-run with a pre-existing `Cannot redeclare wp_parse_url()` Patchwork fatal that also reproduces on the unmodified base tree (verified by stashing these changes). No new tests or failures are introduced; `tests/php/ImageOptimisationTest.php` passes cleanly in isolation.

## Files Changed

- `includes/class-image-optimisation.php`
- `patchwork.json`
- `tests/php/ImageOptimisationTest.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-576`.*