### PR TITLE
[Autofix] Code Quality Issues Found in master

### DIFF
--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -461,9 +461,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 		 * Preloading a stylesheet core is about to inline is a wasted request, so
 		 * the URL is skipped in that case.
 		 *
-		 * @param string $css_url       URL of the combined stylesheet.
-		 * @param int|string $version   Cache-busting version suffix.
-		 * @param string $css_file_path Absolute path to the combined CSS file.
+		 * @param string     $css_url       URL of the combined stylesheet.
+		 * @param int|string $version       Cache-busting version suffix.
+		 * @param string     $css_file_path Absolute path to the combined CSS file.
 		 * @return void
 		 * @since 2.15.0
 		 */

--- a/includes/class-htaccess-handler.php
+++ b/includes/class-htaccess-handler.php
@@ -83,8 +83,8 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Htaccess_Handler' ) ) {
 			return array(
 				'<IfModule mod_deflate.c>',
 				'    # Compress HTML, CSS, JavaScript, Text, XML, and Fonts',
-'    # NOTE: WOFF2 is omitted intentionally — WOFF2 files are already pre-compressed (Brotli)',
-'    # at the binary level, so DEFLATE would add no benefit (and can bloat output).',
+				'    # NOTE: WOFF2 is omitted intentionally — WOFF2 files are already pre-compressed (Brotli)',
+				'    # at the binary level, so DEFLATE would add no benefit (and can bloat output).',
 				'    AddOutputFilterByType DEFLATE text/plain',
 				'    AddOutputFilterByType DEFLATE text/html',
 				'    AddOutputFilterByType DEFLATE text/xml',

--- a/tests/php/CacheTest.php
+++ b/tests/php/CacheTest.php
@@ -118,19 +118,19 @@ class CacheTest extends \PHPUnit\Framework\TestCase {
 	public static function data_provider_register_combine_css_path(): array {
 		return array(
 			'removeUnusedCSS enabled disables inlining' => array(
-				'options'   => array( 'file_optimisation' => array( 'removeUnusedCSS' => true ) ),
-				'filter'    => null,
-				'expected'  => false,
+				'options'  => array( 'file_optimisation' => array( 'removeUnusedCSS' => true ) ),
+				'filter'   => null,
+				'expected' => false,
 			),
 			'opt-out filter disables inlining'          => array(
-				'options'   => array( 'file_optimisation' => array() ),
-				'filter'    => false,
-				'expected'  => false,
+				'options'  => array( 'file_optimisation' => array() ),
+				'filter'   => false,
+				'expected' => false,
 			),
 			'default enables inlining'                  => array(
-				'options'   => array( 'file_optimisation' => array() ),
-				'filter'    => true,
-				'expected'  => true,
+				'options'  => array( 'file_optimisation' => array() ),
+				'filter'   => true,
+				'expected' => true,
 			),
 		);
 	}
@@ -185,11 +185,11 @@ class CacheTest extends \PHPUnit\Framework\TestCase {
 	 */
 	public static function data_provider_get_styles_inline_limit(): array {
 		return array(
-			'WP 6.8 defaults to 20KB'     => array( '6.8', false, 20000 ),
-			'WP 6.9 defaults to 40KB'     => array( '6.9', false, 40000 ),
-			'WP 7.0 defaults to 40KB'     => array( '7.0', false, 40000 ),
+			'WP 6.8 defaults to 20KB'          => array( '6.8', false, 20000 ),
+			'WP 6.9 defaults to 40KB'          => array( '6.9', false, 40000 ),
+			'WP 7.0 defaults to 40KB'          => array( '7.0', false, 40000 ),
 			'unknown version defaults to 40KB' => array( '', false, 40000 ),
-			'filter override wins'        => array( '7.0', true, 50000 ),
+			'filter override wins'             => array( '7.0', true, 50000 ),
 		);
 	}
 
@@ -272,7 +272,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase {
 		$fs      = \Mockery::mock();
 		$fs->shouldReceive( 'is_dir' )->andReturn( true );
 		$fs->shouldReceive( 'delete' )->andReturnUsing(
-			static function ( $path, $recursive = true ) use ( &$deleted ) {
+			static function ( $path ) use ( &$deleted ) {
 				$deleted[] = $path;
 				return true;
 			}

--- a/tests/php/stubs/minify-css-functions.php
+++ b/tests/php/stubs/minify-css-functions.php
@@ -12,7 +12,7 @@
  * @package PerformanceOptimise\Tests
  */
 
-// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound, WordPress.WP.GlobalVariablesOverride.Prohibited
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound, WordPress.WP.GlobalVariablesOverride.Prohibited, WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid, Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
 if ( ! function_exists( 'wp_maybe_inline_styles' ) ) {
 	/**


### PR DESCRIPTION
## Fixes #583

## What Was Changed

# Fix Summary — Issue #583 (Code Quality Issues Found in master)

### What Was Done

Resolved all 22 WordPress Coding Standards (WPCS) violations reported in issue #583 across 4 files. `composer lint` (PHPCS) now reports **0 errors / 0 warnings** repo-wide, so the `psalm-wpcs-check.yml` and `daily-audit.yml` CI gates pass again.

### Approach

The findings fell into two buckets. The 17 auto-fixable alignment/indentation issues (array double-arrow alignment in test data providers, unindented array items, `@param` docblock alignment) were fixed by hand to match PHPCBF's exact output, keeping the diff minimal and reviewable. The remaining 5 required two deliberate, non-mechanical decisions:

1. **Unused `$recursive` closure parameter** — removed the parameter entirely. The Mockery `delete()` stub only needs `$path`; PHP silently ignores extra arguments, so the 2-arg `$fs->delete( $cache_dir, true )` calls in `delete_all_cache_files()` (class-cache.php:1499, 1507, 1519, 1539) still work unchanged.
2. **`WP_Filesystem()` stub** — the stub deliberately mirrors core's exact function name and signature so `function_exists()` reports a real install, but the camel-case name and intentionally-ignored params trip WPCS. Rather than rename the stub (which would break the mirroring contract), extended the existing file-level `phpcs:disable` comment to also suppress `ValidFunctionName.FunctionNameInvalid` and `UnusedFunctionParameter.FoundAfterLastUsed`. An inline `phpcs:disable` before the function was not viable because a comment between the docblock and function breaks `Squiz.Commenting.FunctionComment.Missing`.

### Key Changes

- `tests/php/CacheTest.php` — Re-aligned array double arrows to the longest-key column in `data_provider_register_combine_css_path()` (lines 121-133) and `data_provider_get_styles_inline_limit()` (lines 188-192); removed the unused `$recursive` parameter from the Mockery `delete()` closure (line 275). Resolves 13 `WordPress.Arrays.MultipleStatementAlignment` warnings + 1 `Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed` warning.

- `tests/php/stubs/minify-css-functions.php` — Extended the existing file-level `phpcs:disable` comment to suppress `WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid` (snake_case error for the core-mirroring `WP_Filesystem()` name) and `Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed` (3 intentionally-ignored parameter warnings). Resolves 4 findings.

- `includes/class-htaccess-handler.php` — Restored tab indentation to the two comment lines in `get_rules()` so they align with sibling array items. Resolves `Generic.WhiteSpace.ScopeIndent.Incorrect` and `WordPress.Arrays.ArrayIndentation.ItemNotAligned` (4 findings).

- `includes/class-cache.php` — Aligned `$css_url` / `$css_file_path` `@param` lines with `$version` after the longest type (`int|string`). Resolves `Squiz.Commenting.FunctionComment.SpacingAfterParamType` (2 findings).

### Verification

All required checks pass:
- `npm run lint:js` — pass (0 errors; 1 pre-existing warning unrelated to this change)
- `composer lint` — pass (0 errors, 0 warnings)
- `npm test` — 23 suites / 255 tests pass
- `npm run build` — compiled successfully; build output unchanged

## Files Changed

- `includes/class-cache.php`
- `includes/class-htaccess-handler.php`
- `tests/php/CacheTest.php`
- `tests/php/stubs/minify-css-functions.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-583`.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified why WOFF2 compression rules are excluded from generated server configuration.

* **Tests**
  * Improved test formatting and simplified mocked filesystem cleanup behavior.
  * Updated code-quality checks for test helper functions.

* **Chores**
  * Standardized PHPDoc parameter alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->