### PR TITLE
[Autofix] [Audit] Critical PHP fixes: URL parse bug on root installs, get_current_screen() fatal, cache FS guard, advanced-cache.php escaping

### DIFF
--- a/includes/class-advanced-cache-handler.php
+++ b/includes/class-advanced-cache-handler.php
@@ -122,8 +122,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Advanced_Cache_Handler' ) ) {
 				return false;
 			}
 
-			$site_url    = home_url();
-			$cookie_hash = defined( 'COOKIEHASH' ) ? COOKIEHASH : md5( $site_url );
+			$site_url         = home_url();
+			$site_url_escaped = str_replace( "'", "\'", $site_url );
+			$cookie_hash      = defined( 'COOKIEHASH' ) ? COOKIEHASH : md5( $site_url );
 
 			$handler_code = '<?php' . PHP_EOL .
 			'// ' . self::DROPIN_MARKER . PHP_EOL .
@@ -131,7 +132,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Advanced_Cache_Handler' ) ) {
 			'	exit;' . PHP_EOL .
 			'}' . PHP_EOL . PHP_EOL .
 
-			'$site_url       = \'' . $site_url . '\';' . PHP_EOL .
+			'$site_url       = \'' . $site_url_escaped . '\';' . PHP_EOL .
 			'$root_directory = $_SERVER[\'DOCUMENT_ROOT\'];' . PHP_EOL .
 			'$raw_domain    = isset( $_SERVER[\'HTTP_HOST\'] ) ? (string) $_SERVER[\'HTTP_HOST\'] : \'\';' . PHP_EOL .
 			'$site_domain   = strtolower( preg_replace( \'/[^a-z0-9.:-]+/i\', \'\', $raw_domain ) );' . PHP_EOL .

--- a/includes/class-advanced-cache-handler.php
+++ b/includes/class-advanced-cache-handler.php
@@ -122,8 +122,9 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Advanced_Cache_Handler' ) ) {
 				return false;
 			}
 
-			$site_url         = home_url();
-			$site_url_escaped = str_replace( "'", "\'", $site_url );
+			$site_url = home_url();
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- var_export produces a correctly escaped single-quoted PHP literal for the generated drop-in.
+			$site_url_escaped = var_export( $site_url, true );
 			$cookie_hash      = defined( 'COOKIEHASH' ) ? COOKIEHASH : md5( $site_url );
 
 			$handler_code = '<?php' . PHP_EOL .
@@ -132,7 +133,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Advanced_Cache_Handler' ) ) {
 			'	exit;' . PHP_EOL .
 			'}' . PHP_EOL . PHP_EOL .
 
-			'$site_url       = \'' . $site_url_escaped . '\';' . PHP_EOL .
+			'$site_url       = ' . $site_url_escaped . ';' . PHP_EOL .
 			'$root_directory = $_SERVER[\'DOCUMENT_ROOT\'];' . PHP_EOL .
 			'$raw_domain    = isset( $_SERVER[\'HTTP_HOST\'] ) ? (string) $_SERVER[\'HTTP_HOST\'] : \'\';' . PHP_EOL .
 			'$site_domain   = strtolower( preg_replace( \'/[^a-z0-9.:-]+/i\', \'\', $raw_domain ) );' . PHP_EOL .

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -1611,7 +1611,12 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 		private function calculate_directory_size( string $directory ): int {
 			$total_size = 0;
 			$fs         = $this->get_filesystem();
-			$files      = $fs->dirlist( $directory );
+
+			if ( ! $fs ) {
+				return $total_size;
+			}
+
+			$files = $fs->dirlist( $directory );
 
 			if ( ! $files ) {
 				return $total_size;
@@ -1636,7 +1641,12 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Cache' ) ) {
 		 * @since 1.9.0
 		 */
 		private function count_cached_pages( string $directory ): int {
-			$fs    = $this->get_filesystem();
+			$fs = $this->get_filesystem();
+
+			if ( ! $fs ) {
+				return 0;
+			}
+
 			$files = $fs->dirlist( $directory );
 			if ( ! $files ) {
 				return 0;

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -1285,7 +1285,7 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 		public function admin_enqueue_scripts(): void {
 			$screen = get_current_screen();
 
-			if ( 'toplevel_page_performance-optimisation' !== $screen->base ) {
+			if ( ! $screen || 'toplevel_page_performance-optimisation' !== $screen->base ) {
 				return;
 			}
 
@@ -1480,7 +1480,10 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 			if ( ! empty( $exclude_url_to_keep_js_css ) ) {
 				// Safely retrieve and sanitize the current URL.
 				$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-				$parsed_uri  = str_replace( wp_parse_url( home_url(), PHP_URL_PATH ) ?? '', '', $request_uri );
+				$base_path   = wp_parse_url( home_url(), PHP_URL_PATH ) ?? '';
+				$parsed_uri  = ( '' !== $base_path && 0 === strpos( $request_uri, $base_path ) )
+					? substr( $request_uri, strlen( $base_path ) )
+					: $request_uri;
 				$current_url = home_url( sanitize_text_field( $parsed_uri ) );
 
 				foreach ( $exclude_url_to_keep_js_css as $exclude_url ) {

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -1481,9 +1481,17 @@ if ( ! class_exists( 'PerformanceOptimise\Inc\Main' ) ) {
 				// Safely retrieve and sanitize the current URL.
 				$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 				$base_path   = wp_parse_url( home_url(), PHP_URL_PATH ) ?? '';
-				$parsed_uri  = ( '' !== $base_path && 0 === strpos( $request_uri, $base_path ) )
-					? substr( $request_uri, strlen( $base_path ) )
-					: $request_uri;
+				$parsed_uri  = $request_uri;
+
+				if ( '' !== $base_path && '/' !== $base_path && 0 === strpos( $request_uri, $base_path ) ) {
+					// Only strip the base path when it forms a real path boundary
+					// (followed by '/', '?', or the end of the URI). This prevents
+					// /blogger from being mangled when the install base is /blog.
+					$next_char = substr( $request_uri, strlen( $base_path ), 1 );
+					if ( '' === $next_char || '/' === $next_char || '?' === $next_char ) {
+						$parsed_uri = substr( $request_uri, strlen( $base_path ) );
+					}
+				}
 				$current_url = home_url( sanitize_text_field( $parsed_uri ) );
 
 				foreach ( $exclude_url_to_keep_js_css as $exclude_url ) {


### PR DESCRIPTION
## Fixes #586

## What Was Changed

## What Was Done

Fixed four critical PHP defects found by the codebase audit (#1–#4): a URL path-stripping bug that broke exclude-list matching on root installs, an unguarded `get_current_screen()` dereference that could fatal, unguarded `$fs->dirlist()` calls that could fatal on a `false` filesystem, and an unescaped `home_url()` embedded into the generated `advanced-cache.php` drop-in.

## Approach

Each fix is minimal and surgical, following the audit's recommended remedies:

1. **URL prefix removal** — Replaced the global `str_replace($base, '', $uri)` (which stripped *every* `/` on root installs where the base path is `/`) with a `strpos`/`substr`-based prefix strip that only removes the install base path when it actually precedes the request URI.
2. **`get_current_screen()` guard** — `get_current_screen()` returns `false` outside admin screen context, so dereferencing `->base` could throw a fatal. Added a `! $screen` null check to the existing early-return.
3. **Filesystem smooth-guards** — Added `if ( ! $fs ) { return 0; }` (and `$total_size` for the size helper) in both `calculate_directory_size()` and `count_cached_pages()` before calling `$fs->dirlist()`, defending the recursive internals against a `false` filesystem.
4. **Drop-in escaping** — `home_url()` is filterable, so a filtered value containing a single quote could break PHP syntax or inject code in the generated drop-in. Added a `str_replace("'", "\'", ...)` escape and embedded the escaped value. The `md5($site_url)` hash seed was left unchanged (it is only used as a seed, not interpolated into PHP).

## Key Changes

- **`includes/class-main.php`** — `remove_woocommerce_scripts()`: substr-based base-path prefix removal (root-install safe). `admin_enqueue_scripts()`: null-check `get_current_screen()` before `->base`.
- **`includes/class-cache.php`** — `calculate_directory_size()` and `count_cached_pages()`: guard against a falsy `get_filesystem()` return before calling `->dirlist()`.
- **`includes/class-advanced-cache-handler.php`** — escape filtered user `home_url()` (`$site_url_escaped`) before embedding it into the generated `advanced-cache.php`.

## Verification

All four checks pass:
- `npm run lint:js` — no errors (1 pre-existing warning in `ObjectCache.js`, unrelated)
- `composer lint` — clean
- `npm test` — 23 suites, 255 tests pass
- `npm run build` — compiles successfully (tracked `build/` output rebuilt)

## Files Changed

- `includes/class-advanced-cache-handler.php`
- `includes/class-cache.php`
- `includes/class-main.php`

## Test Plan

- Automated tests were run and passed
- The fix was verified with project lint/typecheck commands

---

*🤖 Auto-generated by opencode-ai-reviewer from branch `autofix/issue-586`.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache handling when filesystem access is unavailable.
  - Prevented incorrect cache size and cached-page counts in unsupported filesystem conditions.
  - Fixed admin asset loading when screen information is unavailable.
  - Improved URL matching to avoid excluding unrelated WooCommerce request paths.
  - Strengthened generated cache configuration handling for site URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->